### PR TITLE
 #KWM-001 · Secret handling hardening + rotation runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,39 @@
-# Database Configuration
+# ============================================================================
+# Kiteezi Waste Management — environment variables
+# ============================================================================
+# Copy this file to `.env` (never commit `.env`) and replace placeholder
+# values with real credentials from the secret manager / provider dashboards.
+#
+# Variables prefixed with NEXT_PUBLIC_ are exposed to the browser by design.
+# Do NOT add server-only secrets with that prefix.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Database — Neon PostgreSQL (server-only)
+# ----------------------------------------------------------------------------
+# Format: postgresql://USER:PASSWORD@HOST/DB?sslmode=require&channel_binding=require
+# Source: https://console.neon.tech → Project → Connection string
 DATABASE_URL='your-postgresql-database-url-here'
 
-# Web3Auth Configuration
+# ----------------------------------------------------------------------------
+# Web3Auth — wallet + social login (client-bundled)
+# ----------------------------------------------------------------------------
+# Source: https://dashboard.web3auth.io → Project → Client ID
+# This value ships in the client bundle; security relies on the domain
+# allowlist set in the Web3Auth dashboard, not on this string being secret.
 NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID='your-web3auth-client-id-here'
 
-# Web3Auth Network (determines which Web3Auth network to use)
-# Options: sapphire_devnet, sapphire_mainnet, testnet, mainnet, cyan
-# Use 'sapphire_devnet' for development/testing
-# Use 'sapphire_mainnet' for production
+# Web3Auth network (controls which Web3Auth backend is contacted).
+# Options: sapphire_devnet | sapphire_mainnet | testnet | mainnet | cyan
+# Use sapphire_devnet for development; sapphire_mainnet for production.
+# NOTE: As of this writing the code in components/Header.tsx hard-codes
+# SAPPHIRE_DEVNET regardless of this value (see issue KWM-007).
 NEXT_PUBLIC_WEB3AUTH_NETWORK='sapphire_devnet'
 
-# RPC Configuration
-# Get a free API key from https://www.ankr.com/rpc/
+# ----------------------------------------------------------------------------
+# EVM RPC — used by Web3Auth provider (client-bundled)
+# ----------------------------------------------------------------------------
 # Format: https://rpc.ankr.com/eth_sepolia/YOUR_API_KEY
+# Free tier: https://www.ankr.com/rpc/  (sign up + generate key)
+# A leaked key allows others to consume your rate-limit quota.
+NEXT_PUBLIC_RPC_URL='https://rpc.ankr.com/eth_sepolia/your-ankr-api-key-here'

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,16 @@
 
 # testing
 /coverage
-.env
+
 # next.js
 /.next/
 /out/
+
+# environment files — never commit secrets
+# (.env.example is tracked because it documents required variables)
+.env
+.env.*
+!.env.example
 
 # production
 /build
@@ -24,9 +30,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# local env files
-.env*.local
 
 # vercel
 .vercel

--- a/docs/security/secret-rotation.md
+++ b/docs/security/secret-rotation.md
@@ -1,0 +1,136 @@
+# Secret Rotation Runbook
+
+**Owner:** repository maintainer (currently single-developer)
+**Audience:** anyone with admin access to Neon, Vercel, Web3Auth, and Ankr
+**Cadence:** rotate on a schedule and on demand (suspected leak, contributor offboarding, anomaly in logs)
+
+This runbook documents how to rotate every credential the application uses, in what order, and how to verify the rotation succeeded. It is the operational counterpart to issue **KWM-001**.
+
+---
+
+## 1. Inventory of secrets
+
+| # | Variable | Provider | Where it lives | Server-only? | Rotation cadence |
+|---|----------|----------|----------------|--------------|------------------|
+| 1 | `DATABASE_URL` | Neon | Vercel envs + local `.env` | ✅ yes | Every 90 days, or on suspicion |
+| 2 | `NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID` | Web3Auth | Vercel envs + local `.env` + browser bundle | ❌ (client-bundled) | On project re-init only; security relies on domain allowlist |
+| 3 | `NEXT_PUBLIC_WEB3AUTH_NETWORK` | n/a (string flag) | Vercel envs + local `.env` | ❌ | Change only when migrating dev/prod |
+| 4 | `NEXT_PUBLIC_RPC_URL` | Ankr | Vercel envs + local `.env` + browser bundle | ❌ (client-bundled) | Every 180 days, or on rate-limit anomaly |
+
+The `NEXT_PUBLIC_*` variables ship in the client JavaScript bundle and are therefore **not secrets** in the traditional sense — anyone with the URL can read them. They are listed here because they have monetary or rate-limit exposure if abused.
+
+---
+
+## 2. Pre-rotation checklist
+
+Before rotating anything:
+
+- [ ] Tag the current production deploy in Vercel so you can roll back.
+- [ ] Confirm you have admin access to Neon, Vercel, Web3Auth, Ankr.
+- [ ] Identify a low-traffic window (rotation may cause brief 5xx errors on cold connections).
+- [ ] Open the local `.env` and back it up to a password manager (1Password / Bitwarden) so the new values land somewhere durable.
+- [ ] Confirm no scheduled jobs / migrations are running against the database.
+
+---
+
+## 3. Rotate `DATABASE_URL` (Neon)
+
+### 3.1 Generate a new role + password
+
+1. Sign in to **https://console.neon.tech**.
+2. Select project → **Roles** tab.
+3. Either:
+   - **Recommended:** create a new role `kiteezi_app_YYYYMMDD` with a fresh password; assign it `CONNECT` + read/write on the schemas in use (or reuse the existing role and click **Reset password**).
+   - **Alternative:** select the existing `neondb_owner` and click **Reset password** (simpler; loses audit-by-name).
+4. Copy the new connection string (Neon shows it once; persist immediately to your password manager).
+
+### 3.2 Update environments (in this order, top-down)
+
+1. **Local** — edit your `.env`, paste the new `DATABASE_URL`. Restart `next dev`.
+2. **Vercel preview** — `vercel env rm DATABASE_URL preview` then `vercel env add DATABASE_URL preview` (paste new value). Or in the dashboard: Project → Settings → Environment Variables.
+3. **Vercel production** — same as preview but for the `production` scope. **Deploy to apply** (`vercel deploy --prod`).
+4. **Vercel development** — same, for the `development` scope.
+
+### 3.3 Verify
+
+- Local: `npm run dev` → smoke-test the home page; verify no `Error: invalid password` in console.
+- Production: open the deployed URL; verify auth/notifications still load.
+- Run `psql "$DATABASE_URL" -c '\dt'` against the new URL — should list tables.
+
+### 3.4 Decommission the old password
+
+1. In Neon, **delete the old role** OR **rotate the old role's password again to something random** (locks it out without leaving an unused role hanging around).
+2. Verify the old connection string no longer works: `psql "<OLD_URL>" -c '\dt'` should fail with `password authentication failed`.
+
+---
+
+## 4. Rotate `NEXT_PUBLIC_RPC_URL` (Ankr API key)
+
+### 4.1 Generate a new Ankr key
+
+1. Sign in to **https://www.ankr.com/rpc/**.
+2. Project → **API Keys** → **Create** (label e.g. `kiteezi-prod-YYYYMMDD`).
+3. Copy the full Sepolia endpoint URL (`https://rpc.ankr.com/eth_sepolia/<NEW_KEY>`).
+
+### 4.2 Update environments
+
+1. Local `.env`.
+2. Vercel envs (`preview`, `production`, `development`).
+3. Redeploy.
+
+### 4.3 Verify + retire
+
+- Hit `https://rpc.ankr.com/eth_sepolia/<NEW_KEY>` with a `{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}` POST — expect a 200 with current block.
+- In Ankr dashboard, **disable** the old key once production traffic has switched (give it ~30 minutes for CDN / preview deploys to roll over).
+
+---
+
+## 5. Rotate `NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID` (Web3Auth)
+
+> Only do this if the Web3Auth project is being decommissioned or if the project's domain allowlist has been compromised. The client ID is public by design.
+
+### 5.1 Tighten without rotating (preferred)
+
+1. **https://dashboard.web3auth.io** → Project → **Allowed Origins**.
+2. Ensure ONLY the production domain, `*.vercel.app` preview prefix, and `http://localhost:3000` are listed.
+3. Remove any wildcards (`*`), localhost variants you don't use, or stale staging domains.
+
+### 5.2 Full rotation (only if compromised)
+
+1. Create a **new** Web3Auth project for `Sapphire Devnet` (or `Sapphire Mainnet` for prod).
+2. Set Allowed Origins to your domains only.
+3. Copy the new Client ID.
+4. Update Vercel envs and local `.env`.
+5. Deploy.
+6. **Migrate user wallets first.** Web3Auth-issued wallets are tied to the (verifier × clientId) pair — changing the clientId may produce new wallet addresses for existing users. Plan a user-facing migration before doing this; do not do it casually.
+7. Once verified, archive the old project in the Web3Auth dashboard.
+
+---
+
+## 6. Post-rotation
+
+- [ ] Confirm all four environments (local, preview, dev, prod) use the new values.
+- [ ] Update **1Password / Bitwarden / Doppler** with the new values; mark the old ones archived.
+- [ ] Add a calendar reminder for next rotation per §1 cadence.
+- [ ] Note the rotation in `docs/security/CHANGELOG-secrets.md` (date, who, why) — create the file on first rotation.
+- [ ] If rotation was triggered by a suspected leak, also write up an incident note in `docs/security/incidents/YYYY-MM-DD-<short-slug>.md` covering: what leaked, how, blast radius, what we changed, what we'd do differently.
+
+---
+
+## 7. What NOT to do
+
+- **Do NOT** commit `.env`. The `.gitignore` blocks `.env` and `.env.*` while keeping `.env.example`; respect those rules.
+- **Do NOT** paste secrets into GitHub issues, PR descriptions, Discord, screenshots, or AI-assistant context windows.
+- **Do NOT** put server-only secrets behind a `NEXT_PUBLIC_` prefix. That prefix forces them into the client bundle.
+- **Do NOT** re-export server secrets via `next.config.mjs`'s `env:` field — that also leaks them to the client bundle. (See issue KWM-002.)
+- **Do NOT** rotate the Web3Auth client ID casually — it can orphan user wallets.
+
+---
+
+## 8. Rotation log
+
+(Maintain manually below; one row per rotation event.)
+
+| Date (UTC) | Variable | Triggered by | Operator | Notes |
+|-----------|----------|--------------|----------|-------|
+| _none yet_ | | | | |


### PR DESCRIPTION
 Closes #8

  ## Summary

  Implements the prep-work portion of KWM-001 (rotate leaked secrets and remove `.env` from git history). Discovery during implementation revealed that
  **`.env` has never been committed** to any branch in this repo's history, so the "rewrite history / force-push" half of the original issue is not
  applicable. Detail below.

  This PR ships the hygiene + documentation half:

  - Tightens `.gitignore` so every `.env.*` variant is excluded except the tracked `.env.example`.
  - Resyncs `.env.example` with the variables the code actually reads (including the previously-undocumented `NEXT_PUBLIC_RPC_URL`).
  - Adds `docs/security/secret-rotation.md` — a full rotation runbook for Neon, Web3Auth, and Ankr.

  The actual rotation (Neon password reset + Vercel env update) is **operational work** that has to happen in provider dashboards. It is documented in the
  runbook and listed under "Follow-ups" below — it is not part of this PR.

  ## Discovery — correction to the audit

  The audit (`docs/project-audit/TECHNICAL_AUDIT.md` §9, defect **C-1**) claimed `.env` was committed to the repository and that `.gitignore` only excluded
  `.env*.local`. Both claims are incorrect:

  | Check | Result |
  |---|---|
  | `git ls-files \| grep ^\.env` | Only `.env.example` is tracked |
  | `git log --all --full-history -- .env` | Empty — never committed in any ref |
  | `git rev-list --all --objects` for `.env` blob | Empty |
  | `git check-ignore -v .env` | `.gitignore:11:.env` — already ignored |

  Consequence: no `git-filter-repo`, no force-push, no history rewrite needed. The KWM-001 acceptance criterion *"`.env` no longer appears in `git log --all
  -- .env`"* is already satisfied (and was satisfied before this PR).

  The companion finding **C-2** (`DATABASE_URL` re-exported to the client bundle via `next.config.mjs`) is **not addressed here** — that is its own issue,
  KWM-002.

  ## Secrets inventory

  | Variable | Provider | Sensitivity | Rotation cadence |
  |---|---|---|---|
  | `DATABASE_URL` | Neon | 🔴 server-only secret | every 90 days, or on suspicion |
  | `NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID` | Web3Auth | 🟡 client-bundled (security via domain allowlist) | on project re-init only |
  | `NEXT_PUBLIC_WEB3AUTH_NETWORK` | n/a | 🟡 string flag | only when migrating env |
  | `NEXT_PUBLIC_RPC_URL` | Ankr | 🟡 client-bundled (rate-limit exposure) | every 180 days |

  Full details, including the "why does a `NEXT_PUBLIC_` variable still need rotation" reasoning, are in `docs/security/secret-rotation.md` §1.

  ## What changed

  | File | Change |
  |---|---|
  | `.gitignore` | Removed scattered `.env` / `.env*.local` lines; consolidated into a single block: `.env`, `.env.*`, `!.env.example`. Belt-and-braces
  against any future `.env.local`, `.env.production`, etc. |
  | `.env.example` | Added missing `NEXT_PUBLIC_RPC_URL` (the code reads it but the example didn't declare it). Clarified that `NEXT_PUBLIC_*` variables ship
   in the client bundle and are not server secrets. Noted that `NEXT_PUBLIC_WEB3AUTH_NETWORK` is currently unused (KWM-007 will fix the hard-coded network in
   `Header.tsx`). |
  | `docs/security/secret-rotation.md` *(new)* | 136-line runbook covering: secret inventory, pre-rotation checklist, step-by-step rotation for Neon / Ankr /
   Web3Auth, post-rotation verification, what NOT to do, rotation log table. |

  ## Acceptance criteria (from issue KWM-001)

  - [x] `.gitignore` updated to broadly exclude env files.
  - [x] `docs/security/secret-rotation.md` added.
  - [N/A] Remove `.env` from git history — never was in history.
  - [N/A] `git-filter-repo` invocation — no history to rewrite.
  - [ ] **Neon `DATABASE_URL` rotated** — operational; see runbook §3. Not part of this PR.
  - [ ] **Web3Auth client ID regenerated or domain allowlist tightened** — operational; see runbook §5. Recommended action is allowlist tightening (§5.1)
  rather than full rotation (§5.2) because the value is public-by-design and full rotation can orphan user wallets.
  - [ ] **Ankr API key rotated** — operational; see runbook §4.
  - [ ] **Team notified** — single-developer repo; n/a until contributors join.

  ## Follow-ups (for the maintainer, not this PR)

  After this PR merges:

  1. Rotate `DATABASE_URL` per `docs/security/secret-rotation.md` §3 (Neon dashboard → reset password → update local `.env` → update Vercel envs in all three
   scopes → redeploy → verify old credential is dead).
  2. Rotate Ankr `NEXT_PUBLIC_RPC_URL` per §4.
  3. Tighten Web3Auth allowed origins per §5.1.
  4. Record each rotation in the log table at the bottom of the runbook.

  ## Out of scope

  - KWM-002 — removing `DATABASE_URL` from `next.config.mjs:env`. Separate issue, separate PR.
  - KWM-005 — moving secrets to a managed secret store (Vercel project envs / Doppler). Separate issue. The runbook references it.
  - Any change to application code. This PR touches only `.gitignore`, `.env.example`, and `docs/`.

  ## Verification done locally

  - `git ls-files | grep .env` → still only `.env.example`. ✅
  - `git check-ignore -v .env` → still ignored, via the new combined block. ✅
  - `git check-ignore -v .env.local .env.production .env.staging` → all ignored. ✅
  - `git check-ignore -v .env.example` → **not** ignored (allow-listed). ✅
  - `npm run build` (Next.js compile) not re-run for this PR — no code change.

  ## Risk

  Minimal — documentation + git hygiene only. Worst case the `.gitignore` rule is too broad; mitigated by the `!.env.example` exception.

  ---
  Summary of what just happened

  - Branch: security/kwm-001-secret-handling (off origin/dev)
  - Commits (3):
    - 1534c55 chore(security): broaden .gitignore to cover .env.* variants
    - 4c5d841 chore(security): sync .env.example with current variables
    - 11a6e7e docs(security): add secret rotation runbook
  - Push: succeeded
  - PR creation URL: https://github.com/muzuvajoshua/kiteezi-waste-management/pull/new/security/kwm-001-secret-handling
  - Closes: issue #8 (KWM-001)