### PR TITLE
KWM-002 · Remove DATABASE_URL client exposure via next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-    env:{
-        DATABASE_URL: process.env.DATABASE_URL,
-        WEB3_AUTH_CLIENTID: process.env.WEB3_AUTH_CLIENTID,
-    },
-};
+const nextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
 Closes #9

  ## Summary

  Removes the `env:` block from `next.config.mjs` that was inlining `DATABASE_URL` into the browser bundle via webpack's `DefinePlugin`. Production builds
  will no longer ship Neon credentials in client JavaScript.

  ## Root cause

  ```js
  // next.config.mjs (before)
  const nextConfig = {
      env:{
          DATABASE_URL: process.env.DATABASE_URL,
          WEB3_AUTH_CLIENTID: process.env.WEB3_AUTH_CLIENTID,
      },
  };
  ```

  Next.js's `env:` field is implemented as a `DefinePlugin` substitution that performs **build-time string replacement of `process.env.<KEY>` in both server
  and browser bundles**, bypassing the `NEXT_PUBLIC_` wall entirely. Because `utils/db/dbConfig.jsx` references `process.env.DATABASE_URL` at module top
  level and is reachable from the `"use client"` file `components/Header.tsx` via `@/utils/db/actions`, the full Neon connection string
  (`neondb_owner:npg_…@…/kiteezimanagement`) was being baked into every client chunk that imported the chain.

  Secondary defect: `WEB3_AUTH_CLIENTID` (no `NEXT_PUBLIC_` prefix) was also re-exported but is read by zero files — dead config that widened the bad
  pattern.

  ## Change

  One file, six lines removed:

  ```diff
   /** @type {import('next').NextConfig} */
  -const nextConfig = {
  -    env:{
  -        DATABASE_URL: process.env.DATABASE_URL,
  -        WEB3_AUTH_CLIENTID: process.env.WEB3_AUTH_CLIENTID,
  -    },
  -};
  +const nextConfig = {};

   export default nextConfig;
  ```

  ## Why this is safe

  | Concern | Reality |
  |---|---|
  | Server stops finding `DATABASE_URL` | No — Vercel injects it into the Node process env at request time; `process.env.DATABASE_URL` still resolves
  correctly on the server |
  | `drizzle-kit` breaks | No — `drizzle.config.js` reads `process.env.DATABASE_URL` from the shell at CLI time, independent of `next.config.mjs` |
  | Something reads `WEB3_AUTH_CLIENTID` | No — grep returns zero consumers; the variable is dead |
  | Existing Vercel deploys break | No — only the build-time client inlining changes; server runtime behaviour is unchanged |

  ## Verification

  Production build run locally, then bundle scanned:

  | Check | Result |
  |---|---|
  | `grep DATABASE_URL .next/static` | Matches the *variable name reference* `ea.env.DATABASE_URL` (resolves to `undefined` in the browser at runtime, with
  the `env:` block gone). No value. |
  | `grep -e neondb_owner -e ep-polished-mud -e kiteezimanagement -e npg_ .next/static` | **0 matches.** The DB credential string is no longer in any client
  chunk. ✅ |
  | Same grep against `.next/server` | 0 matches — confirms `DefinePlugin` substitution is off and the server reads from `process.env` at runtime (the
  correct path). ✅ |

  The local build required a one-off `NODE_TLS_REJECT_UNAUTHORIZED=0` env override to bypass a machine-specific TLS revocation-check failure on `next/font`'s
   Google Fonts fetch (same issue as during the Next.js 15.5.15 bump). The override was not committed; Vercel's build environment does not have this issue.

  ## Lingering related issue (out of scope, separate ticket)

  The string `ea.env.DATABASE_URL` still appears in client chunks because `utils/db/dbConfig.jsx` is being tree-shaken into the client bundle through the
  import chain `components/Header.tsx → @/utils/db/actions → ./dbConfig`. This is an architectural defect — server-only code is still reachable from a client
   component — and it is the subject of **KWM-003** (add a `"use server"` directive to `utils/db/actions.ts`). KWM-002 closes only the *value-level leak*;
  KWM-003 closes the *import-chain* leak. The runtime client-side reference is safe today because it resolves to `undefined` with no value to leak.

  ## Acceptance criteria (from issue KWM-002)

  - [x] `env:` block removed from `next.config.mjs`.
  - [x] Build inspected post-change; no `DATABASE_URL` **value** present in any client chunk.
  - [x] Production build smoke-tested locally (compiled successfully).

  ## Rollback

  ```
  git revert 1f6cf09
  git push
  ```

  One-commit revert, no env-var changes needed in Vercel.