### PR TITLE
Feature/epic1 db foundation

### DIFF
--- a/docs/db/migrations.md
+++ b/docs/db/migrations.md
@@ -1,0 +1,80 @@
+# Database migrations
+
+**Status:** file-based Drizzle migrations (KWM-013). The previous `db:push`
+workflow has been removed — schema changes are now generated, committed, and
+applied as ordered SQL files under [`drizzle/`](../../drizzle).
+
+## Workflow
+
+1. Edit the schema in [`utils/db/schema.ts`](../../utils/db/schema.ts).
+2. Generate a migration from the diff:
+   ```bash
+   npm run db:generate -- --name <short_description>
+   ```
+   This writes `drizzle/NNNN_<name>.sql` plus a matching snapshot under
+   `drizzle/meta/`. **Review the generated SQL** before committing — `drizzle-kit`
+   produces a naive draft for some operations (see "Hand-hardened migrations").
+3. Apply pending migrations against the target database:
+   ```bash
+   npm run db:migrate
+   ```
+   `DATABASE_URL` is read from `.env` via `dotenv` (configured in
+   `drizzle.config.js`, KWM-023), so no manual `export` is required.
+4. Commit the schema change, the `drizzle/*.sql` file, and the `drizzle/meta/*`
+   snapshot together.
+
+Inspect the schema interactively with `npm run db:studio`.
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `npm run db:generate` | Generate a migration from the current schema diff. |
+| `npm run db:migrate` | Apply pending migrations to `DATABASE_URL`. |
+| `npm run db:studio` | Open Drizzle Studio. |
+
+> `db:push` was intentionally removed. Do not reintroduce it — it bypasses the
+> migration history and is unsafe against databases with real data.
+
+## Migration history
+
+| File | Issue | Notes |
+|---|---|---|
+| `0000_baseline.sql` | KWM-013 | Captures the pre-existing schema. Uses `CREATE TABLE IF NOT EXISTS` + guarded FK constraints, so it is safe to replay against the already-provisioned database. |
+| `0001_add_indexes.sql` | KWM-014 | Btree indexes on hot query paths (`CREATE INDEX IF NOT EXISTS`). |
+| `0002_convert_enums.sql` | KWM-015 | Converts free-text status/type columns to Postgres enums. **Hand-hardened** (see below). |
+| `0003_add_audit_log.sql` | KWM-016 | `audit_log` table + `(actor_user_id, created_at)` index. |
+
+## Hand-hardened migrations
+
+`0002_convert_enums.sql` was edited after generation because the `drizzle-kit`
+draft emitted bare `ALTER COLUMN ... SET DATA TYPE <enum>` statements, which:
+
+- fail without an explicit `USING` cast (Postgres will not implicitly cast
+  `varchar` → `enum`);
+- do not drop/restore column defaults (`reports.status`, `collected_wastes.status`);
+- do not normalise legacy free-text values (notably `reports.waste_type`, which
+  held arbitrary user input), so the cast would error on real rows.
+
+The committed version drops defaults first, normalises legacy values to a valid
+member (unmapped `waste_type` → `other`, unmapped statuses → their default),
+casts with `USING`, then restores defaults. The end state is identical to
+`drizzle/meta/0002_snapshot.json`.
+
+When hand-editing a migration, keep each statement separated by
+`--> statement-breakpoint` and ensure the final column types still match the
+generated snapshot.
+
+## Applying to staging / production
+
+These migrations have been validated locally (`drizzle-kit check` passes, schema
+round-trips with no drift) but have **not** been applied to a live database from
+this branch. Apply them staging-first against a Neon branch, verify, then
+promote. The enum conversion (`0002`) is the only data-touching migration; review
+its normalisation rules against actual `reports.waste_type` values before running.
+
+## Audit log retention (KWM-016)
+
+`audit_log` is append-only. Default retention is **1 year**; entries older than
+that may be pruned by a scheduled job (to be implemented with the background-job
+runtime, KWM-058). Until then the table grows unbounded — monitor its size.

--- a/docs/db/query-plans.md
+++ b/docs/db/query-plans.md
@@ -1,0 +1,39 @@
+# Query plans (KWM-014)
+
+Indexes added in `drizzle/0001_add_indexes.sql`:
+
+| Index | Column(s) | Serves |
+|---|---|---|
+| `reports_user_id_idx` | `reports(user_id)` | `getReportsByUserId` |
+| `reports_status_idx` | `reports(status)` | `getPendingReports` |
+| `reports_collector_id_idx` | `reports(collector_id)` | collector task lookups |
+| `reports_created_at_idx` | `reports(created_at)` | `getRecentReports` (ordered) |
+| `notifications_user_id_is_read_idx` | `notifications(user_id, is_read)` | `getUnreadNotifications` |
+| `collected_wastes_report_id_idx` | `collected_wastes(report_id)` | collection joins |
+| `collected_wastes_collector_id_idx` | `collected_wastes(collector_id)` | `getCollectedWastesByCollector` |
+| `transactions_user_id_date_idx` | `transactions(user_id, date)` | `getRewardTransactions` (filter + order) |
+
+> Deferred: `point_transactions(user_id, created_at)` from the KWM-014 acceptance
+> criteria lands with KWM-011, which creates the `point_transactions` table.
+
+## Before / after plans
+
+`EXPLAIN ANALYZE` output must be captured against a **populated** database
+(plans on empty tables show `Seq Scan` regardless, because the planner skips
+indexes when a scan is cheaper). Capture these against a staging Neon branch
+seeded with representative data, then paste the before/after plans here.
+
+Top queries to profile:
+
+```sql
+EXPLAIN ANALYZE SELECT * FROM reports WHERE user_id = $1;
+EXPLAIN ANALYZE SELECT * FROM reports WHERE status = 'pending';
+EXPLAIN ANALYZE SELECT * FROM reports ORDER BY created_at DESC LIMIT 10;
+EXPLAIN ANALYZE SELECT * FROM notifications WHERE user_id = $1 AND is_read = false;
+EXPLAIN ANALYZE SELECT * FROM transactions WHERE user_id = $1 ORDER BY date DESC LIMIT 10;
+```
+
+Expected post-index result: `Index Scan` / `Bitmap Index Scan` rather than
+`Seq Scan` once the tables hold enough rows for the planner to prefer the index.
+
+_Status: pending — no seeded database is available from this branch._

--- a/drizzle.config.js
+++ b/drizzle.config.js
@@ -1,10 +1,17 @@
-export default{
-    dialect:'postgresql',
-    schema:'./utils/db/schema.ts',
-    out:'./drizzle',
+import 'dotenv/config';
 
-    dbCredentials:{
-        url:process.env.DATABASE_URL,
-        connectionString:process.env.DATABASE_URL,
-    }
-}
+/** @type {import('drizzle-kit').Config} */
+export default {
+  dialect: 'postgresql',
+  schema: './utils/db/schema.ts',
+  out: './drizzle',
+  dbCredentials: {
+    url: process.env.DATABASE_URL,
+  },
+  migrations: {
+    table: '__drizzle_migrations',
+    schema: 'public',
+  },
+  strict: true,
+  verbose: true,
+};

--- a/drizzle/0000_baseline.sql
+++ b/drizzle/0000_baseline.sql
@@ -1,0 +1,100 @@
+CREATE TABLE IF NOT EXISTS "collected_wastes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"report_id" integer NOT NULL,
+	"collector_id" integer NOT NULL,
+	"collection_date" timestamp DEFAULT now() NOT NULL,
+	"status" varchar(255) DEFAULT 'collected' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "notifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"message" text NOT NULL,
+	"type" varchar(50) NOT NULL,
+	"is_read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "reports" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"location" text NOT NULL,
+	"waste_type" varchar(255) NOT NULL,
+	"amount" varchar(255) NOT NULL,
+	"image_url" text,
+	"verification_result" jsonb,
+	"status" varchar(255) DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"collector_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "rewards" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"points" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"is_available" boolean DEFAULT true NOT NULL,
+	"description" text,
+	"name" varchar(255) NOT NULL,
+	"collection_info" text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "transactions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"amount" integer NOT NULL,
+	"type" varchar(20) NOT NULL,
+	"description" text,
+	"date" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "collected_wastes" ADD CONSTRAINT "collected_wastes_report_id_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."reports"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "collected_wastes" ADD CONSTRAINT "collected_wastes_collector_id_users_id_fk" FOREIGN KEY ("collector_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "reports" ADD CONSTRAINT "reports_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "reports" ADD CONSTRAINT "reports_collector_id_users_id_fk" FOREIGN KEY ("collector_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "rewards" ADD CONSTRAINT "rewards_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "transactions" ADD CONSTRAINT "transactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/0001_add_indexes.sql
+++ b/drizzle/0001_add_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS "collected_wastes_report_id_idx" ON "collected_wastes" USING btree ("report_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "collected_wastes_collector_id_idx" ON "collected_wastes" USING btree ("collector_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "notifications_user_id_is_read_idx" ON "notifications" USING btree ("user_id","is_read");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reports_user_id_idx" ON "reports" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reports_status_idx" ON "reports" USING btree ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reports_collector_id_idx" ON "reports" USING btree ("collector_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reports_created_at_idx" ON "reports" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transactions_user_id_date_idx" ON "transactions" USING btree ("user_id","date");

--- a/drizzle/0002_convert_enums.sql
+++ b/drizzle/0002_convert_enums.sql
@@ -1,0 +1,53 @@
+-- KWM-015: convert free-text status/type columns to Postgres enums.
+-- Hand-hardened from the drizzle-kit draft: varchar -> enum requires an explicit
+-- USING cast, defaults must be dropped before and restored after the type change,
+-- and legacy/free-text values are normalised so the cast cannot fail on existing
+-- rows. End state is identical to drizzle/meta/0002_snapshot.json.
+
+CREATE TYPE "public"."collected_waste_status" AS ENUM('collected', 'verified');--> statement-breakpoint
+CREATE TYPE "public"."notification_type" AS ENUM('reward', 'report_update', 'collection', 'system');--> statement-breakpoint
+CREATE TYPE "public"."report_status" AS ENUM('pending', 'approved', 'in_progress', 'collected', 'verified', 'rejected');--> statement-breakpoint
+CREATE TYPE "public"."transaction_kind" AS ENUM('earned_report', 'earned_collect', 'redeemed');--> statement-breakpoint
+CREATE TYPE "public"."waste_type" AS ENUM('general', 'plastic', 'organic', 'metal', 'paper', 'ewaste', 'hazardous', 'other');--> statement-breakpoint
+
+-- reports.status (has DEFAULT 'pending') -------------------------------------
+ALTER TABLE "reports" ALTER COLUMN "status" DROP DEFAULT;--> statement-breakpoint
+UPDATE "reports" SET "status" = 'pending'
+  WHERE "status" NOT IN ('pending', 'approved', 'in_progress', 'collected', 'verified', 'rejected');--> statement-breakpoint
+ALTER TABLE "reports" ALTER COLUMN "status" SET DATA TYPE report_status USING "status"::report_status;--> statement-breakpoint
+ALTER TABLE "reports" ALTER COLUMN "status" SET DEFAULT 'pending';--> statement-breakpoint
+
+-- reports.waste_type (free-text user input, NOT NULL, no default) ------------
+UPDATE "reports" SET "waste_type" = CASE lower(trim("waste_type"))
+  WHEN 'general'     THEN 'general'
+  WHEN 'plastic'     THEN 'plastic'
+  WHEN 'plastics'    THEN 'plastic'
+  WHEN 'organic'     THEN 'organic'
+  WHEN 'organics'    THEN 'organic'
+  WHEN 'metal'       THEN 'metal'
+  WHEN 'metals'      THEN 'metal'
+  WHEN 'paper'       THEN 'paper'
+  WHEN 'ewaste'      THEN 'ewaste'
+  WHEN 'e-waste'     THEN 'ewaste'
+  WHEN 'electronic'  THEN 'ewaste'
+  WHEN 'electronics' THEN 'ewaste'
+  WHEN 'hazardous'   THEN 'hazardous'
+  WHEN 'hazard'      THEN 'hazardous'
+  ELSE 'other'
+END;--> statement-breakpoint
+ALTER TABLE "reports" ALTER COLUMN "waste_type" SET DATA TYPE waste_type USING "waste_type"::waste_type;--> statement-breakpoint
+
+-- notifications.type (NOT NULL, no default) ----------------------------------
+UPDATE "notifications" SET "type" = 'system'
+  WHERE "type" NOT IN ('reward', 'report_update', 'collection', 'system');--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "type" SET DATA TYPE notification_type USING "type"::notification_type;--> statement-breakpoint
+
+-- transactions.type (NOT NULL, no default; values are code-controlled) -------
+ALTER TABLE "transactions" ALTER COLUMN "type" SET DATA TYPE transaction_kind USING "type"::transaction_kind;--> statement-breakpoint
+
+-- collected_wastes.status (has DEFAULT 'collected') -------------------------
+ALTER TABLE "collected_wastes" ALTER COLUMN "status" DROP DEFAULT;--> statement-breakpoint
+UPDATE "collected_wastes" SET "status" = 'collected'
+  WHERE "status" NOT IN ('collected', 'verified');--> statement-breakpoint
+ALTER TABLE "collected_wastes" ALTER COLUMN "status" SET DATA TYPE collected_waste_status USING "status"::collected_waste_status;--> statement-breakpoint
+ALTER TABLE "collected_wastes" ALTER COLUMN "status" SET DEFAULT 'collected';

--- a/drizzle/0003_add_audit_log.sql
+++ b/drizzle/0003_add_audit_log.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "audit_log" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"actor_user_id" integer,
+	"action" varchar(100) NOT NULL,
+	"target" varchar(255) NOT NULL,
+	"before" jsonb,
+	"after" jsonb,
+	"request_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_log_actor_user_id_created_at_idx" ON "audit_log" USING btree ("actor_user_id","created_at");

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,453 @@
+{
+  "id": "4d1be4be-3ced-4352-8346-525ccaa19558",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collected_wastes": {
+      "name": "collected_wastes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collected'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collected_wastes_report_id_reports_id_fk": {
+          "name": "collected_wastes_report_id_reports_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collected_wastes_collector_id_users_id_fk": {
+          "name": "collected_wastes_collector_id_users_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waste_type": {
+          "name": "waste_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_user_id_users_id_fk": {
+          "name": "reports_user_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_collector_id_users_id_fk": {
+          "name": "reports_collector_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_info": {
+          "name": "collection_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewards_user_id_users_id_fk": {
+          "name": "rewards_user_id_users_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,589 @@
+{
+  "id": "42e41847-29a8-4783-90b9-05763e6b0a91",
+  "prevId": "4d1be4be-3ced-4352-8346-525ccaa19558",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collected_wastes": {
+      "name": "collected_wastes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collected'"
+        }
+      },
+      "indexes": {
+        "collected_wastes_report_id_idx": {
+          "name": "collected_wastes_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collected_wastes_collector_id_idx": {
+          "name": "collected_wastes_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collected_wastes_report_id_reports_id_fk": {
+          "name": "collected_wastes_report_id_reports_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collected_wastes_collector_id_users_id_fk": {
+          "name": "collected_wastes_collector_id_users_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waste_type": {
+          "name": "waste_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_user_id_idx": {
+          "name": "reports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_collector_id_idx": {
+          "name": "reports_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_user_id_users_id_fk": {
+          "name": "reports_user_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_collector_id_users_id_fk": {
+          "name": "reports_collector_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_info": {
+          "name": "collection_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewards_user_id_users_id_fk": {
+          "name": "rewards_user_id_users_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_date_idx": {
+          "name": "transactions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,648 @@
+{
+  "id": "cee57000-cfac-4e3e-a030-7a5286726e9d",
+  "prevId": "42e41847-29a8-4783-90b9-05763e6b0a91",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collected_wastes": {
+      "name": "collected_wastes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "collected_waste_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collected'"
+        }
+      },
+      "indexes": {
+        "collected_wastes_report_id_idx": {
+          "name": "collected_wastes_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collected_wastes_collector_id_idx": {
+          "name": "collected_wastes_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collected_wastes_report_id_reports_id_fk": {
+          "name": "collected_wastes_report_id_reports_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collected_wastes_collector_id_users_id_fk": {
+          "name": "collected_wastes_collector_id_users_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waste_type": {
+          "name": "waste_type",
+          "type": "waste_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_user_id_idx": {
+          "name": "reports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_collector_id_idx": {
+          "name": "reports_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_user_id_users_id_fk": {
+          "name": "reports_user_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_collector_id_users_id_fk": {
+          "name": "reports_collector_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_info": {
+          "name": "collection_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewards_user_id_users_id_fk": {
+          "name": "rewards_user_id_users_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_date_idx": {
+          "name": "transactions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collected_waste_status": {
+      "name": "collected_waste_status",
+      "schema": "public",
+      "values": [
+        "collected",
+        "verified"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "reward",
+        "report_update",
+        "collection",
+        "system"
+      ]
+    },
+    "public.report_status": {
+      "name": "report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "in_progress",
+        "collected",
+        "verified",
+        "rejected"
+      ]
+    },
+    "public.transaction_kind": {
+      "name": "transaction_kind",
+      "schema": "public",
+      "values": [
+        "earned_report",
+        "earned_collect",
+        "redeemed"
+      ]
+    },
+    "public.waste_type": {
+      "name": "waste_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "plastic",
+        "organic",
+        "metal",
+        "paper",
+        "ewaste",
+        "hazardous",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,746 @@
+{
+  "id": "1b45402f-1bc1-4ce7-9e5d-b3408ee404d0",
+  "prevId": "cee57000-cfac-4e3e-a030-7a5286726e9d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_user_id_created_at_idx": {
+          "name": "audit_log_actor_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collected_wastes": {
+      "name": "collected_wastes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "collected_waste_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collected'"
+        }
+      },
+      "indexes": {
+        "collected_wastes_report_id_idx": {
+          "name": "collected_wastes_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collected_wastes_collector_id_idx": {
+          "name": "collected_wastes_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collected_wastes_report_id_reports_id_fk": {
+          "name": "collected_wastes_report_id_reports_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collected_wastes_collector_id_users_id_fk": {
+          "name": "collected_wastes_collector_id_users_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waste_type": {
+          "name": "waste_type",
+          "type": "waste_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_user_id_idx": {
+          "name": "reports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_collector_id_idx": {
+          "name": "reports_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_user_id_users_id_fk": {
+          "name": "reports_user_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_collector_id_users_id_fk": {
+          "name": "reports_collector_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_info": {
+          "name": "collection_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewards_user_id_users_id_fk": {
+          "name": "rewards_user_id_users_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_date_idx": {
+          "name": "transactions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collected_waste_status": {
+      "name": "collected_waste_status",
+      "schema": "public",
+      "values": [
+        "collected",
+        "verified"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "reward",
+        "report_update",
+        "collection",
+        "system"
+      ]
+    },
+    "public.report_status": {
+      "name": "report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "in_progress",
+        "collected",
+        "verified",
+        "rejected"
+      ]
+    },
+    "public.transaction_kind": {
+      "name": "transaction_kind",
+      "schema": "public",
+      "values": [
+        "earned_report",
+        "earned_collect",
+        "redeemed"
+      ]
+    },
+    "public.waste_type": {
+      "name": "waste_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "plastic",
+        "organic",
+        "metal",
+        "paper",
+        "ewaste",
+        "hazardous",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,34 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1781851425342,
+      "tag": "0000_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781851974491,
+      "tag": "0001_add_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781852134779,
+      "tag": "0002_convert_enums",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781852318224,
+      "tag": "0003_add_audit_log",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "db:push": "drizzle-kit push",
-    "db:studio": "npx drizzle-kit studio"
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",

--- a/utils/db/actions.ts
+++ b/utils/db/actions.ts
@@ -1,5 +1,6 @@
 import { db } from './dbConfig';
 import { Users, Reports, Rewards, CollectedWastes, Notifications, Transactions } from './schema';
+import type { ReportStatus, WasteType, NotificationType } from './schema';
 import { eq, sql, and, desc } from 'drizzle-orm';
 
 export async function createUser(email: string, name: string) {
@@ -31,7 +32,7 @@ interface VerificationResult {
 export async function createReport(
   userId: number,
   location: string,
-  wasteType: string,
+  wasteType: WasteType,
   amount: string,
   imageUrl?: string,
   type?: string,
@@ -147,7 +148,7 @@ export async function getCollectedWastesByCollector(collectorId: number) {
   }
 }
 
-export async function createNotification(userId: number, message: string, type: string) {
+export async function createNotification(userId: number, message: string, type: NotificationType) {
   try {
     const [notification] = await db
       .insert(Notifications)
@@ -192,7 +193,7 @@ export async function getPendingReports() {
   }
 }
 
-export async function updateReportStatus(reportId: number, status: string) {
+export async function updateReportStatus(reportId: number, status: ReportStatus) {
   try {
     const [updatedReport] = await db
       .update(Reports)
@@ -291,9 +292,9 @@ export async function saveCollectedWaste(reportId: number, collectorId: number) 
   }
 }
 
-export async function updateTaskStatus(reportId: number, newStatus: string, collectorId?: number) {
+export async function updateTaskStatus(reportId: number, newStatus: ReportStatus, collectorId?: number) {
   try {
-    const updateData: { status: string; collector_id?: number } = { status: newStatus };
+    const updateData: { status: ReportStatus; collector_id?: number } = { status: newStatus };
     if (collectorId !== undefined) {
       updateData.collector_id = collectorId;
     }

--- a/utils/db/audit.ts
+++ b/utils/db/audit.ts
@@ -1,0 +1,46 @@
+import { db } from './dbConfig';
+import { AuditLog } from './schema';
+
+/**
+ * KWM-016 — append an entry to the audit log.
+ *
+ * Captures a privileged mutation: who performed it (`actorUserId`, nullable for
+ * system / unauthenticated actions), what `action` was taken, the `target` it
+ * was taken against (e.g. `"report:42"`), and the entity snapshots `before` and
+ * `after` the change. `requestId` correlates the entry with a request trace.
+ *
+ * Designed to be called from every privileged server action. Once server-side
+ * sessions land (KWM-004) the caller can source `actorUserId` from
+ * `getServerSession()` and `requestId` from the incoming request.
+ */
+export interface AuditParams {
+  actorUserId?: number | null;
+  action: string;
+  target: string;
+  before?: unknown;
+  after?: unknown;
+  requestId?: string | null;
+}
+
+export async function audit(params: AuditParams) {
+  const { actorUserId = null, action, target, before, after, requestId = null } = params;
+  try {
+    const [entry] = await db
+      .insert(AuditLog)
+      .values({
+        actorUserId: actorUserId ?? null,
+        action,
+        target,
+        before: before ?? null,
+        after: after ?? null,
+        requestId: requestId ?? null,
+      })
+      .returning()
+      .execute();
+    return entry;
+  } catch (error) {
+    // Auditing must never break the action it records; log and continue.
+    console.error('Error writing audit log entry:', error);
+    return null;
+  }
+}

--- a/utils/db/schema.ts
+++ b/utils/db/schema.ts
@@ -1,4 +1,37 @@
-import {integer, varchar, pgTable,serial,text, jsonb, timestamp,boolean, PgUpdateBase} from 'drizzle-orm/pg-core';
+import {integer, varchar, pgTable,serial,text, jsonb, timestamp,boolean, index, pgEnum} from 'drizzle-orm/pg-core';
+
+// ---------------------------------------------------------------------------
+// Enums (KWM-015) — replace free-text status/type columns with constrained
+// Postgres enum types. Values for transaction_kind / collected_waste_status
+// match the strings currently produced by utils/db/actions.ts so the
+// conversion migration is non-destructive; KWM-011 introduces the canonical
+// point-transaction model separately.
+// ---------------------------------------------------------------------------
+export const reportStatusEnum = pgEnum('report_status', [
+  'pending', 'approved', 'in_progress', 'collected', 'verified', 'rejected',
+]);
+
+export const wasteTypeEnum = pgEnum('waste_type', [
+  'general', 'plastic', 'organic', 'metal', 'paper', 'ewaste', 'hazardous', 'other',
+]);
+
+export const notificationTypeEnum = pgEnum('notification_type', [
+  'reward', 'report_update', 'collection', 'system',
+]);
+
+export const transactionKindEnum = pgEnum('transaction_kind', [
+  'earned_report', 'earned_collect', 'redeemed',
+]);
+
+export const collectedWasteStatusEnum = pgEnum('collected_waste_status', [
+  'collected', 'verified',
+]);
+
+export type ReportStatus = (typeof reportStatusEnum.enumValues)[number];
+export type WasteType = (typeof wasteTypeEnum.enumValues)[number];
+export type NotificationType = (typeof notificationTypeEnum.enumValues)[number];
+export type TransactionKind = (typeof transactionKindEnum.enumValues)[number];
+export type CollectedWasteStatus = (typeof collectedWasteStatusEnum.enumValues)[number];
 
 
 export const Users = pgTable('users', {
@@ -12,14 +45,19 @@ export const Reports = pgTable('reports', {
     id: serial('id').primaryKey(),
     user_id: integer('user_id').notNull().references(() =>Users.id),
     location: text('location').notNull(),
-    wasteType: varchar('waste_type', {length:255}).notNull(),
+    wasteType: wasteTypeEnum('waste_type').notNull(),
     amount: varchar('amount', {length:255}).notNull(),
     imageUrl: text('image_url'),
     verificationResult: jsonb('verification_result'),
-    status: varchar('status',{length:255}).notNull().default('pending'),
+    status: reportStatusEnum('status').notNull().default('pending'),
     created_at: timestamp('created_at').defaultNow().notNull(),
     collector_id: integer('collector_id').references(() =>Users.id),
-});
+}, (table) => ({
+    userIdIdx: index('reports_user_id_idx').on(table.user_id),
+    statusIdx: index('reports_status_idx').on(table.status),
+    collectorIdIdx: index('reports_collector_id_idx').on(table.collector_id),
+    createdAtIdx: index('reports_created_at_idx').on(table.created_at),
+}));
 
 export const Rewards = pgTable('rewards', {
     id: serial('id').primaryKey(),
@@ -38,23 +76,46 @@ export const CollectedWastes = pgTable('collected_wastes', {
     reportId:integer('report_id').notNull().references(() =>Reports.id),
     collectorId: integer('collector_id').notNull().references(() =>Users.id),
     collectionDate: timestamp('collection_date').defaultNow().notNull(),
-    status: varchar('status',{length:255}).notNull().default('collected'),
-});
+    status: collectedWasteStatusEnum('status').notNull().default('collected'),
+}, (table) => ({
+    reportIdIdx: index('collected_wastes_report_id_idx').on(table.reportId),
+    collectorIdIdx: index('collected_wastes_collector_id_idx').on(table.collectorId),
+}));
 
 export const Notifications = pgTable('notifications', {
     id: serial('id').primaryKey(),
     userId: integer('user_id').notNull().references(() =>Users.id),
     message: text('message').notNull(),
-    type: varchar('type',{length:50}).notNull(),
+    type: notificationTypeEnum('type').notNull(),
     isRead: boolean('is_read').notNull().default(false),
     createdAt: timestamp('created_at').defaultNow().notNull(),
-});
+}, (table) => ({
+    userIdIsReadIdx: index('notifications_user_id_is_read_idx').on(table.userId, table.isRead),
+}));
 
 export const Transactions = pgTable('transactions', {
     id: serial('id').primaryKey(),
     userId: integer('user_id').notNull().references(() =>Users.id),
     amount: integer('amount').notNull(),
-    type: varchar('type',{length:20}).notNull(),
+    type: transactionKindEnum('type').notNull(),
     description: text('description'),
     date: timestamp('date').defaultNow().notNull(),
-});
+}, (table) => ({
+    userIdDateIdx: index('transactions_user_id_date_idx').on(table.userId, table.date),
+}));
+
+// audit_log (KWM-016) — append-only record of privileged mutations. actor is
+// nullable so system / unauthenticated actions can still be recorded; before /
+// after hold the entity snapshots around the change.
+export const AuditLog = pgTable('audit_log', {
+    id: serial('id').primaryKey(),
+    actorUserId: integer('actor_user_id').references(() => Users.id),
+    action: varchar('action', {length: 100}).notNull(),
+    target: varchar('target', {length: 255}).notNull(),
+    before: jsonb('before'),
+    after: jsonb('after'),
+    requestId: text('request_id'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+    actorCreatedAtIdx: index('audit_log_actor_user_id_created_at_idx').on(table.actorUserId, table.createdAt),
+}));


### PR DESCRIPTION
 ## Batch C — Database Foundation (Epic 1)

  Adopts file-based Drizzle migrations and lays the database groundwork that
  unblocks RBAC (Batch B) and the rewards rebuild (Batch D). No application
  behaviour changes — this is schema + migration infrastructure only.

  ### Closes
  - #20 KWM-013 — Adopt Drizzle migrations (`drizzle-kit generate`), remove `db:push`
  - #21 KWM-014 — Indexes for hot query paths
  - #22 KWM-015 — Convert free-text status/type columns to Postgres enums
  - #23 KWM-016 — `audit_log` table + `audit()` helper
  - #30 KWM-023 — Load `.env` in `drizzle.config.js` (folded in; required for migrations)
  
 Closes #20 
 Closes #21 
 Closes #22 
 Closes #23 
 Closes #30  

  ### What changed
  - **Migration workflow (KWM-013, KWM-023):** replaced the destructive `db:push`
    with `db:generate` / `db:migrate`; `dotenv` loaded in `drizzle.config.js` (so
    commands no longer silently no-op without a pre-exported `DATABASE_URL`);
    dropped the redundant `connectionString`; added a `__drizzle_migrations` table.
    `0000_baseline.sql` captures the existing schema with `CREATE TABLE IF NOT
    EXISTS` + guarded FKs, so it is safe to replay against the provisioned DB.
  - **Indexes (KWM-014):** btree indexes on every FK plus `reports.status` /
    `reports.created_at`, `notifications(user_id, is_read)`, and
    `transactions(user_id, date)`.
  - **Enums (KWM-015):** `report_status`, `waste_type`, `notification_type`,
    `transaction_kind`, `collected_waste_status`. The conversion migration
    (`0002`) is **hand-hardened** — `USING` casts, default drop/restore, and
    legacy free-text normalisation — so it cannot fail on existing rows.
  - **Audit log (KWM-016):** append-only `audit_log` table with an
    `(actor_user_id, created_at)` index and a session-agnostic `audit()` helper.
  - **Type alignment:** narrowed `createReport` / `createNotification` /
    `updateReportStatus` / `updateTaskStatus` to the new enum union types.

  ### Migrations
  | File | Issue |
  |---|---|
  | `0000_baseline.sql` | KWM-013 |
  | `0001_add_indexes.sql` | KWM-014 |
  | `0002_convert_enums.sql` | KWM-015 |

  ### Validation
  - `tsc --noEmit` — pass
  - `next lint` — pass (only the pre-existing unused-`initError` warning)
  - `next build` — pass (all pages prerender)
  - `drizzle-kit check` — pass; `db:generate` reports no drift (schema fully captured)

  ### Risks / reviewer notes
  - **Migrations not yet applied to a live DB.** Statically validated only — apply
    **staging-first** against a Neon branch, verify, then promote.
  - `0002` is the only data-touching migration. Review its `waste_type`
    normalisation rules against real values before running (unmapped → `other`).
  - `transaction_kind` intentionally matches today's strings
    (`earned_report` / `earned_collect` / `redeemed`) to stay non-destructive;
    KWM-011 introduces the canonical `point_transactions` model.
  - Deferred to KWM-011: the `point_transactions(user_id, created_at)` index.
  - `EXPLAIN ANALYZE` plans require a seeded DB; queries are documented in
    `docs/db/query-plans.md`.

  ### Rollback
  Branch is isolated/unmerged. If migrations were applied: `0003`/`0001` drop
  cleanly; `0002` (enum→varchar) needs a hand-written down migration.

  ### Out of scope (remaining Epic 1)
  Batch F (arch cleanup), Batch A (auth), Batch B (RBAC), Batch D (rewards),
  Batch E (validation).