### PR TITLE
 refactor(epic1): Batch F — architecture cleanup (KWM-006, KWM-007, KWM-022, KWM-024)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,8 @@
-"use client";
-
-import { useState } from "react";
-import { Toaster } from "react-hot-toast";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import Header from "@/components/Header";
-import Sidebar from "@/components/Sidebar";
+import AppShell from "@/components/AppShell";
+
+export { metadata } from "./metadata";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,25 +11,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
   return (
     <html lang="en">
       <body className={inter.className}>
-        <div className="min-h-screen bg-gray-50 flex flex-col">
-          {/* header */}
-          <Header
-            onMenuClick={() => setSidebarOpen(!sidebarOpen)}
-          />
-          <div className="flex flex-1">
-            {/* sidebar */}
-            <Sidebar open={sidebarOpen} />
-            <main className="flex-1 p-4 lg:p-8 ml-0 lg:ml-64 transition-all duration-300">
-              {children}
-            </main>
-          </div>
-        </div>
-        <Toaster />
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/app/metadata.tsx
+++ b/app/metadata.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Kiteezi-Waste-Management",
+  title: "Kiteezi Waste Management System",
   description: "This is an AI waste management system for Kiteezi, Uganda",
 };

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import { Toaster } from "react-hot-toast";
+import Header from "@/components/Header";
+import Sidebar from "@/components/Sidebar";
+
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <Header onMenuClick={() => setSidebarOpen(!sidebarOpen)} />
+      <div className="flex flex-1">
+        <Sidebar open={sidebarOpen} />
+        <main className="flex-1 p-4 lg:p-8 ml-0 lg:ml-64 transition-all duration-300">
+          {children}
+        </main>
+      </div>
+      <Toaster />
+    </div>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -4,20 +4,23 @@ import { useState } from "react";
 import { Toaster } from "react-hot-toast";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
+import { Web3AuthProvider } from "@/components/Web3AuthProvider";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
-      <Header onMenuClick={() => setSidebarOpen(!sidebarOpen)} />
-      <div className="flex flex-1">
-        <Sidebar open={sidebarOpen} />
-        <main className="flex-1 p-4 lg:p-8 ml-0 lg:ml-64 transition-all duration-300">
-          {children}
-        </main>
+    <Web3AuthProvider>
+      <div className="min-h-screen bg-gray-50 flex flex-col">
+        <Header onMenuClick={() => setSidebarOpen(!sidebarOpen)} />
+        <div className="flex flex-1">
+          <Sidebar open={sidebarOpen} />
+          <main className="flex-1 p-4 lg:p-8 ml-0 lg:ml-64 transition-all duration-300">
+            {children}
+          </main>
+        </div>
+        <Toaster />
       </div>
-      <Toaster />
-    </div>
+    </Web3AuthProvider>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,18 +23,14 @@ import {
 
 import { Badge } from "./ui/badge";
 
-import { Web3Auth } from "@web3auth/modal";
-import { CHAIN_NAMESPACES, WEB3AUTH_NETWORK } from "@web3auth/base";
-
-import { EthereumPrivateKeyProvider } from "@web3auth/ethereum-provider";
 import {
-  createUser,
   getUserByEmail,
   getUnreadNotifications,
   getUserBalance,
   markNotificationAsRead,
 } from "@/utils/db/actions";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useWeb3Auth } from "@/components/Web3AuthProvider";
 
 // Custom notification type to avoid conflict with browser's Notification API
 interface NotificationItem {
@@ -46,91 +42,25 @@ interface NotificationItem {
   isRead: boolean;
 }
 
-interface UserInfo {
-  email?: string;
-  name?: string;
-  profileImage?: string;
-  aggregateVerifier?: string;
-  verifier?: string;
-  verifierId?: string;
-  typeOfLogin?: string;
-}
-
-const clientId = process.env.NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID || "";
-
-const chainConfig = {
-  chainNamespace: CHAIN_NAMESPACES.EIP155,
-  chainId: "0xaa36a7",
-  rpcTarget: process.env.NEXT_PUBLIC_RPC_URL || "https://rpc.ankr.com/eth_sepolia",
-  displayName: "Sepolia Testnet",
-  blockExplorerURL: "https://sepolia.etherscan.io",
-  ticker: "ETH",
-  tickerName: "Ethereum",
-  logo: "https://assets.web3auth.io/evm-chains/sepolia.png",
-};
-
-const privateKeyProvider = new EthereumPrivateKeyProvider({
-  config: { chainConfig },
-});
-
-const web3Auth = new Web3Auth({
-  clientId,
-  web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_DEVNET,
-  privateKeyProvider,
-});
-
 interface HeaderProps {
   onMenuClick: () => void;
   totalEarnings?: number;
 }
 
 export default function Header({ onMenuClick }: HeaderProps) {
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [isWeb3AuthReady, setIsWeb3AuthReady] = useState(false);
-  const [initError, setInitError] = useState<string | null>(null);
-  const [userInfor, setUserInfor] = useState<UserInfo | null>(null);
+  const { user, isReady, login, logout } = useWeb3Auth();
   const [notification, setNotification] = useState<NotificationItem[]>([]);
   const [balance, setBalance] = useState(0);
   const isMobile = useMediaQuery("(max-width: 768px)");
-  useEffect(() => {
-    const init = async () => {
-      try {
-        await web3Auth.initModal();
-        setIsWeb3AuthReady(true);
 
-        if (web3Auth.connected) {
-          setLoggedIn(true);
-          const user = await web3Auth.getUserInfo();
-          setUserInfor(user);
-
-          if (user.email) {
-            localStorage.setItem("email", user.email);
-            try {
-              await createUser(user.email, user.name || "Anonymous User");
-            } catch (error) {
-              console.error("Error creating User", error);
-            }
-          }
-        }
-      } catch (error) {
-        console.error("Error initialising Web3Auth", error);
-        setInitError(
-          "Failed to initialize Web3Auth. Please ensure your domain is whitelisted in the Web3Auth dashboard."
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-    init();
-  }, []);
+  const loggedIn = !!user;
 
   useEffect(() => {
     const fetchNotifications = async () => {
-      if (userInfor && userInfor.email) {
-        const user = await getUserByEmail(userInfor.email);
-        if (user) {
-          const unReadNotifications = await getUnreadNotifications(user.id);
+      if (user && user.email) {
+        const dbUser = await getUserByEmail(user.email);
+        if (dbUser) {
+          const unReadNotifications = await getUnreadNotifications(dbUser.id);
           setNotification(unReadNotifications);
         }
       }
@@ -139,14 +69,14 @@ export default function Header({ onMenuClick }: HeaderProps) {
 
     const notificationInterval = setInterval(fetchNotifications, 30000);
     return () => clearInterval(notificationInterval);
-  }, [userInfor]);
+  }, [user]);
 
   useEffect(() => {
     const fetchUserBalance = async () => {
-      if (userInfor && userInfor.email) {
-        const user = await getUserByEmail(userInfor.email);
-        if (user) {
-          const userBalance = await getUserBalance(user.id);
+      if (user && user.email) {
+        const dbUser = await getUserByEmail(user.email);
+        if (dbUser) {
+          const userBalance = await getUserBalance(dbUser.id);
           setBalance(userBalance);
         }
       }
@@ -166,75 +96,11 @@ export default function Header({ onMenuClick }: HeaderProps) {
         handleBalanceUpdate as EventListener
       );
     };
-  }, [userInfor]);
-
-  const login = async () => {
-    if (!web3Auth) {
-      console.error("Web3Auth not initialised");
-      return;
-    }
-    if (!isWeb3AuthReady) {
-      console.error("Web3Auth modal not ready yet. Please wait for initialization to complete.");
-      return;
-    }
-    try {
-      await web3Auth.connect();
-      setLoggedIn(true);
-
-      const user = await web3Auth.getUserInfo();
-      setUserInfor(user);
-
-      if (user.email) {
-        localStorage.setItem("email", user.email);
-        try {
-          await createUser(user.email, user.name || "Anonymous User");
-        } catch (error) {
-          console.error("Error creating User", error);
-        }
-      }
-    } catch (error) {
-      console.error("Error logging in", error);
-    }
-  };
-
-  const logout = async () => {
-    if (!web3Auth) {
-      console.error("Web3Auth not initialised");
-      return;
-    }
-    try {
-      await web3Auth.logout();
-      setLoggedIn(false);
-      setUserInfor(null);
-      localStorage.removeItem("email");
-    } catch (error) {
-      console.error("Error logging out", error);
-    }
-  };
-
-  const getUserInfor = async () => {
-    if (web3Auth.connected) {
-      const user = await web3Auth.getUserInfo();
-      setUserInfor(user);
-
-      if (user.email) {
-        localStorage.setItem("email", user.email);
-        try {
-          await createUser(user.email, user.name || "Anonymous User");
-        } catch (error) {
-          console.error("Error creating User", error);
-        }
-      }
-    }
-  };
+  }, [user]);
 
   const handleNotificationClick = async (notificationId: number) => {
     await markNotificationAsRead(notificationId);
   };
-
-  if (loading) {
-    return <div>Loading web3Auth ........</div>;
-  }
 
    return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
@@ -307,10 +173,10 @@ export default function Header({ onMenuClick }: HeaderProps) {
           {!loggedIn ? (
             <Button
               onClick={login}
-              disabled={!isWeb3AuthReady}
+              disabled={!isReady}
               className="bg-green-600 hover:bg-green-700 text-white text-sm md:text-base disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isWeb3AuthReady ? "Login" : "Initializing..."}
+              {isReady ? "Login" : "Initializing..."}
               <LogIn className="ml-1 md:ml-2 h-4 w-4 md:h-5 md:w-5" />
             </Button>
           ) : (
@@ -322,8 +188,8 @@ export default function Header({ onMenuClick }: HeaderProps) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={getUserInfor}>
-                  {userInfor ? userInfor.name : "Fetch User Info"}
+                <DropdownMenuItem>
+                  {user ? user.name : "User"}
                 </DropdownMenuItem>
                 <DropdownMenuItem>
                   <Link href="/settings">Profile</Link>

--- a/components/Web3AuthProvider.tsx
+++ b/components/Web3AuthProvider.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Web3Auth } from "@web3auth/modal";
+import { CHAIN_NAMESPACES, WEB3AUTH_NETWORK } from "@web3auth/base";
+import { EthereumPrivateKeyProvider } from "@web3auth/ethereum-provider";
+import { createUser } from "@/utils/db/actions";
+
+export interface Web3AuthUser {
+  email?: string;
+  name?: string;
+  profileImage?: string;
+  aggregateVerifier?: string;
+  verifier?: string;
+  verifierId?: string;
+  typeOfLogin?: string;
+}
+
+interface Web3AuthContextValue {
+  user: Web3AuthUser | null;
+  isReady: boolean;
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const Web3AuthContext = createContext<Web3AuthContextValue | null>(null);
+
+const clientId = process.env.NEXT_PUBLIC_WEB3_AUTH_CLIENT_ID || "";
+
+const chainConfig = {
+  chainNamespace: CHAIN_NAMESPACES.EIP155,
+  chainId: "0xaa36a7",
+  rpcTarget:
+    process.env.NEXT_PUBLIC_RPC_URL || "https://rpc.ankr.com/eth_sepolia",
+  displayName: "Sepolia Testnet",
+  blockExplorerURL: "https://sepolia.etherscan.io",
+  ticker: "ETH",
+  tickerName: "Ethereum",
+  logo: "https://assets.web3auth.io/evm-chains/sepolia.png",
+};
+
+export function Web3AuthProvider({ children }: { children: ReactNode }) {
+  const web3AuthRef = useRef<Web3Auth | null>(null);
+  const initStartedRef = useRef(false);
+  const [user, setUser] = useState<Web3AuthUser | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const syncUser = async (web3Auth: Web3Auth) => {
+    const info = (await web3Auth.getUserInfo()) as Web3AuthUser;
+    setUser(info);
+    if (info.email) {
+      localStorage.setItem("email", info.email);
+      try {
+        await createUser(info.email, info.name || "Anonymous User");
+      } catch (error) {
+        console.error("Error creating User", error);
+      }
+    }
+  };
+
+  useEffect(() => {
+    // StrictMode mounts effects twice in dev; guard so the SDK initialises once
+    // and we don't leak modal listeners.
+    if (initStartedRef.current) return;
+    initStartedRef.current = true;
+
+    const init = async () => {
+      try {
+        const privateKeyProvider = new EthereumPrivateKeyProvider({
+          config: { chainConfig },
+        });
+        const web3Auth = new Web3Auth({
+          clientId,
+          web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_DEVNET,
+          privateKeyProvider,
+        });
+        web3AuthRef.current = web3Auth;
+
+        await web3Auth.initModal();
+        setIsReady(true);
+
+        if (web3Auth.connected) {
+          await syncUser(web3Auth);
+        }
+      } catch (error) {
+        console.error("Error initialising Web3Auth", error);
+      }
+    };
+
+    init();
+  }, []);
+
+  const login = async () => {
+    const web3Auth = web3AuthRef.current;
+    if (!web3Auth || !isReady) {
+      console.error("Web3Auth not ready yet. Please wait for initialization.");
+      return;
+    }
+    try {
+      await web3Auth.connect();
+      await syncUser(web3Auth);
+    } catch (error) {
+      console.error("Error logging in", error);
+    }
+  };
+
+  const logout = async () => {
+    const web3Auth = web3AuthRef.current;
+    if (!web3Auth) {
+      console.error("Web3Auth not initialised");
+      return;
+    }
+    try {
+      await web3Auth.logout();
+      setUser(null);
+      localStorage.removeItem("email");
+    } catch (error) {
+      console.error("Error logging out", error);
+    }
+  };
+
+  return (
+    <Web3AuthContext.Provider value={{ user, isReady, login, logout }}>
+      {children}
+    </Web3AuthContext.Provider>
+  );
+}
+
+export function useWeb3Auth(): Web3AuthContextValue {
+  const ctx = useContext(Web3AuthContext);
+  if (!ctx) {
+    throw new Error("useWeb3Auth must be used within a Web3AuthProvider");
+  }
+  return ctx;
+}

--- a/hooks/useMediaQuery.tsx
+++ b/hooks/useMediaQuery.tsx
@@ -6,15 +6,14 @@ export function useMediaQuery(query: string): boolean {
   useEffect(() => {
     const media = window.matchMedia(query);
 
-    if (media.matches !== matches) {
-      setMatches(media.matches);
-    }
+    // Sync immediately in case the query already matches on mount.
+    setMatches(media.matches);
 
-    const listener = () => setMatches(media.matches);
-    media.addListener(listener);
+    const listener = (event: MediaQueryListEvent) => setMatches(event.matches);
+    media.addEventListener("change", listener);
 
-    return () => media.removeListener(listener);
-  }, [matches, query]);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
 
   return matches;
 }

--- a/utils/db/dbConfig.ts
+++ b/utils/db/dbConfig.ts
@@ -3,6 +3,6 @@ import {neon} from '@neondatabase/serverless';
 
 import * as schema from './schema';
 
-const sql = neon(process.env.DATABASE_URL);
+const sql = neon(process.env.DATABASE_URL!);
 
-export const db = drizzle(sql, schema);
+export const db = drizzle(sql, { schema });


### PR DESCRIPTION
 ## Summary
  Batch F of Epic 1 — frontend/architecture cleanup. Restores Server Components,
  centralises Web3Auth, modernises a deprecated browser API, and fixes a
  mistyped DB config file. No behavioural changes to business logic.

  ## Changes

  ### KWM-024 — `dbConfig.jsx` → `dbConfig.ts`
  - Renamed (file contained no JSX; the extension bypassed type-checking).
  - Surfaced and fixed two latent type issues: guard `DATABASE_URL` against the
    `string | undefined` env type, and pass the schema correctly via
    `drizzle(sql, { schema })`.
  - Call sites use the extensionless `./dbConfig` specifier — unchanged.

  ### KWM-022 — `useMediaQuery` deprecated API
  - Replaced `MediaQueryList.addListener/removeListener` with
    `addEventListener('change', …)` / `removeEventListener`.
  - Dropped `matches` from the effect deps so the listener binds once per query
    instead of re-subscribing on every change.

  ### KWM-006 — Server Component root layout
  - `app/layout.tsx` is no longer `"use client"`; it renders `html`/`body` and
    re-exports `metadata`, restoring Server Components, streaming and document
    metadata for the whole tree.
  - New client `<AppShell>` hosts the sidebar-open state and the client-only
    `Toaster`.
  - Aligned `metadata.title` with the product name ("Kiteezi Waste Management

  ### KWM-007 — Web3Auth provider/hook
  - New `<Web3AuthProvider>`: creates the SDK inside a single, StrictMode-safe
    init effect (ref-guarded) and holds it in a ref instead of at module scope.
  - New `useWeb3Auth()` exposes `{ user, isReady, login, logout }`.
  - `Header.tsx` consumes the hook only — no longer instantiates the SDK, runs
    the init effect, or defines login/logout. Removed dead `initError` state
    (and its lint warning) and the full-screen loading gate.

  ## Validation
  - `tsc --noEmit` — passes
  - `next lint` — no warnings or errors
  - `next build` — compiles successfully (5/5 static pages)
  - `npm run dev` — homepage compiles and serves (HTTP 200); document title
    renders as "Kiteezi Waste Management System"

  ## Known follow-up (out of scope for this PR)
  Running the app in the browser surfaces a pre-existing runtime error
  (`neon()` called with no connection string) because `utils/db/actions.ts`
  lacks a `"use server"` boundary and is imported by client components — this is
  **KWM-003** and will be fixed on its own branch.

  Closes #13 
  Closes #14 
  Closes #29 
  Closes #31 