### PR TITLE
 fix(security): add "use server" boundary to db actions (KWM-003)

### DIFF
--- a/utils/db/actions.ts
+++ b/utils/db/actions.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { db } from './dbConfig';
 import { Users, Reports, Rewards, CollectedWastes, Notifications, Transactions } from './schema';
 import type { ReportStatus, WasteType, NotificationType } from './schema';


### PR DESCRIPTION
 ## Summary
  `utils/db/actions.ts` is imported by client components (`Header`,
  `Web3AuthProvider`) but declared no server boundary, so Next.js bundled the
  Drizzle/Neon driver into the browser. On the client, `process.env.DATABASE_URL`
  is undefined, so `neon()` threw *"No database connection string was provided"*
  as soon as the app rendered.

  Adding `"use server";` turns those imports into server-action references — the
  DB layer stays on the server. All exports are already async functions, so they
  are valid server actions; no call sites change.

  ## Validation
  - `tsc --noEmit` — passes (all call sites type-check)
  - `next lint` — no warnings or errors
  - `next build` — compiles successfully
  - `grep -r "drizzle-orm" .next/static` — returns nothing (acceptance criterion)
  - `grep -r "DATABASE_URL" .next/static` — returns nothing (was present before)
  - `npm run dev` — homepage loads (HTTP 200) with no `neon()` error

  ## Acceptance criteria
  - [x] `"use server"` directive added
  - [x] Build clean; no Drizzle code in client chunks
  - [x] All call sites still type-check

  Closes #10 
 