### PR TITLE
ci: add GitHub Actions CI — lint, typecheck, test, build (KWM-061)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+# KWM-061 — gate every PR on lint, typecheck, tests, and a production build.
+# Runs on PRs into the long-lived branches and on direct pushes to them so a
+# merge is re-validated. A red job blocks the merge once these checks are made
+# required in branch protection (see docs / repo settings).
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+# Only read access is needed; keep the token least-privilege.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Runs the test script only once one exists (KWM-060 adds Vitest); a
+      # missing script exits 0 rather than failing the job.
+      - name: Test
+        run: npm test --if-present
+
+      - name: Build
+        run: npm run build
+        env:
+          # Build-time placeholders only. utils/db/dbConfig.ts constructs a Neon
+          # client at module load (neon(process.env.DATABASE_URL!)); no query
+          # runs during `next build`, so a syntactically valid throwaway URL is
+          # enough and connects to nothing. These are NOT secrets.
+          DATABASE_URL: postgresql://user:password@localhost:5432/db
+          SESSION_SECRET: ci-build-placeholder-not-a-real-secret

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"


### PR DESCRIPTION
 ## KWM-061 — GitHub Actions CI

  Adds a CI workflow that gates every PR on lint, typecheck, tests, and a
  production build, so red checks block merges once required in branch protection.

  ### Changes
  - **`.github/workflows/ci.yml`** — single `validate` job on `pull_request` and
    `push` to `dev`/`main`:
    - `npm ci`
    - `npm run lint` (`next lint`)
    - `npm run typecheck` (`tsc --noEmit`)
    - `npm test --if-present` (no-op until KWM-060 adds Vitest, then auto-runs)
    - `npm run build` (`next build`)
    - Node 20, npm cache, least-privilege `contents: read`, concurrency-cancel.
  - **`package.json`** — new `typecheck` script (`tsc --noEmit`).

  ### Notes
  - The build step sets **non-secret placeholder** `DATABASE_URL` /
    `SESSION_SECRET`. `utils/db/dbConfig.ts` builds a Neon client at module load,
    but no query runs during `next build`, so a throwaway localhost URL is enough
    and connects to nothing.
  - Tests use `--if-present` so this PR stays strictly scoped to CI; KWM-060
    (Vitest) will be picked up automatically with no workflow change.

  ### Validation (run locally)
  | Check | Result |
  |-------|--------|
  | `npm run lint` | ✅ no warnings or errors |
  | `npm run typecheck` | ✅ exit 0 |
  | `npm test --if-present` | ✅ exit 0 (no test script yet) |
  | `npm run build` with placeholder env | ✅ compiled, 8/8 static pages |

  ### Acceptance criteria
  - [x] `.github/workflows/ci.yml` runs on PRs into `dev`/`main`.
  - [ ] Branch protection on `dev` and `main` — repo setting (post-merge).
  - [ ] Required status check: **`Lint, typecheck, test, build`** — enable after
        the first CI run.