### PR TITLE
feat(auth): RBAC roles + server-side enforcement, closes C-4 (KWM-008, KWM-009)

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,24 +1,18 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "@/lib/session";
-import { getUserById } from "@/utils/db/actions";
+import { getCurrentUser } from "@/lib/rbac";
 
 export async function GET() {
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ user: null });
-  }
-
-  const user = await getUserById(session.userId);
-  if (!user) {
+  const me = await getCurrentUser();
+  if (!me) {
     return NextResponse.json({ user: null });
   }
 
   return NextResponse.json({
     user: {
-      id: user.id,
-      email: user.email,
-      name: user.name,
-      role: session.role,
+      id: me.userId,
+      email: me.email,
+      name: me.name,
+      roles: me.roles,
     },
   });
 }

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { verifyWeb3AuthToken } from "@/lib/web3auth";
 import { createSessionToken, setSessionCookie } from "@/lib/session";
-import { getUserByEmail, createUser } from "@/utils/db/actions";
+import { getUserByEmail, createUser } from "@/utils/db/internal";
+import { assignRole } from "@/utils/db/roles";
 
 export async function POST(req: Request) {
   let body: unknown;
@@ -31,13 +32,17 @@ export async function POST(req: Request) {
   let dbUser = await getUserByEmail(email);
   if (!dbUser) {
     dbUser = await createUser(email, claims.name || "Anonymous User");
+    if (dbUser) {
+      // Every new user starts as a citizen (KWM-008).
+      await assignRole(dbUser.id, "citizen");
+    }
   }
   if (!dbUser) {
     return NextResponse.json({ error: "Could not resolve user" }, { status: 500 });
   }
 
-  // role defaults to "citizen" until KWM-008 introduces the roles tables.
-  const token = await createSessionToken({ userId: dbUser.id, role: "citizen" });
+  // The cookie carries identity only; roles are resolved from the DB per request.
+  const token = await createSessionToken({ userId: dbUser.id });
   await setSessionCookie(token);
 
   return NextResponse.json({

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,13 +24,13 @@ import {
 import { Badge } from "./ui/badge";
 
 import {
-  getUserByEmail,
   getUnreadNotifications,
   getUserBalance,
   markNotificationAsRead,
 } from "@/utils/db/actions";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useWeb3Auth } from "@/components/Web3AuthProvider";
+import { useSession } from "@/hooks/useSession";
 
 // Custom notification type to avoid conflict with browser's Notification API
 interface NotificationItem {
@@ -49,6 +49,9 @@ interface HeaderProps {
 
 export default function Header({ onMenuClick }: HeaderProps) {
   const { user, isReady, login, logout } = useWeb3Auth();
+  // Identity for data fetching comes from the server session (cookie-derived),
+  // not from the client Web3Auth object. Web3Auth still drives login/logout UI.
+  const { user: sessionUser } = useSession();
   const [notification, setNotification] = useState<NotificationItem[]>([]);
   const [balance, setBalance] = useState(0);
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -57,29 +60,21 @@ export default function Header({ onMenuClick }: HeaderProps) {
 
   useEffect(() => {
     const fetchNotifications = async () => {
-      if (user && user.email) {
-        const dbUser = await getUserByEmail(user.email);
-        if (dbUser) {
-          const unReadNotifications = await getUnreadNotifications(dbUser.id);
-          setNotification(unReadNotifications);
-        }
-      }
+      if (!sessionUser) return;
+      const unReadNotifications = await getUnreadNotifications();
+      setNotification(unReadNotifications);
     };
     fetchNotifications();
 
     const notificationInterval = setInterval(fetchNotifications, 30000);
     return () => clearInterval(notificationInterval);
-  }, [user]);
+  }, [sessionUser]);
 
   useEffect(() => {
     const fetchUserBalance = async () => {
-      if (user && user.email) {
-        const dbUser = await getUserByEmail(user.email);
-        if (dbUser) {
-          const userBalance = await getUserBalance(dbUser.id);
-          setBalance(userBalance);
-        }
-      }
+      if (!sessionUser) return;
+      const userBalance = await getUserBalance();
+      setBalance(userBalance);
     };
     fetchUserBalance();
 
@@ -96,7 +91,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
         handleBalanceUpdate as EventListener
       );
     };
-  }, [user]);
+  }, [sessionUser]);
 
   const handleNotificationClick = async (notificationId: number) => {
     await markNotificationAsRead(notificationId);

--- a/drizzle/0004_add_roles_rbac.sql
+++ b/drizzle/0004_add_roles_rbac.sql
@@ -1,0 +1,54 @@
+CREATE TABLE IF NOT EXISTS "roles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(50) NOT NULL,
+	"description" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "roles_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_roles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"role_id" integer NOT NULL,
+	"granted_at" timestamp DEFAULT now() NOT NULL,
+	"granted_by" integer,
+	CONSTRAINT "user_roles_user_id_role_id_unique" UNIQUE("user_id","role_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_role_id_roles_id_fk" FOREIGN KEY ("role_id") REFERENCES "public"."roles"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_granted_by_users_id_fk" FOREIGN KEY ("granted_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_roles_user_id_idx" ON "user_roles" USING btree ("user_id");--> statement-breakpoint
+
+-- KWM-008 data steps (hand-added; not emitted by drizzle-kit). Both are
+-- idempotent so re-running the migration is safe.
+
+-- Seed the role catalog. Keep in sync with ROLE_NAMES in utils/db/schema.ts.
+INSERT INTO "roles" ("name", "description") VALUES
+	('citizen', 'Default role for any authenticated user; can submit reports and redeem own points'),
+	('operator', 'Field operator; collects waste and records collections'),
+	('supervisor', 'Reviews reports (approve/reject) and oversees operations'),
+	('admin', 'Full administrative access'),
+	('dump_op', 'Dump-site / weighbridge operator')
+ON CONFLICT ("name") DO NOTHING;--> statement-breakpoint
+
+-- Backfill: every existing user receives the default 'citizen' role.
+INSERT INTO "user_roles" ("user_id", "role_id")
+SELECT u."id", r."id" FROM "users" u CROSS JOIN "roles" r
+WHERE r."name" = 'citizen'
+ON CONFLICT ("user_id", "role_id") DO NOTHING;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,901 @@
+{
+  "id": "e84a513b-ae60-4c73-95a9-fc63ca4180c5",
+  "prevId": "1b45402f-1bc1-4ce7-9e5d-b3408ee404d0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_user_id_created_at_idx": {
+          "name": "audit_log_actor_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collected_wastes": {
+      "name": "collected_wastes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "collected_waste_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collected'"
+        }
+      },
+      "indexes": {
+        "collected_wastes_report_id_idx": {
+          "name": "collected_wastes_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collected_wastes_collector_id_idx": {
+          "name": "collected_wastes_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collected_wastes_report_id_reports_id_fk": {
+          "name": "collected_wastes_report_id_reports_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collected_wastes_collector_id_users_id_fk": {
+          "name": "collected_wastes_collector_id_users_id_fk",
+          "tableFrom": "collected_wastes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waste_type": {
+          "name": "waste_type",
+          "type": "waste_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "collector_id": {
+          "name": "collector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_user_id_idx": {
+          "name": "reports_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_collector_id_idx": {
+          "name": "reports_collector_id_idx",
+          "columns": [
+            {
+              "expression": "collector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_user_id_users_id_fk": {
+          "name": "reports_user_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_collector_id_users_id_fk": {
+          "name": "reports_collector_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "collector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_info": {
+          "name": "collection_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rewards_user_id_users_id_fk": {
+          "name": "rewards_user_id_users_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_date_idx": {
+          "name": "transactions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_roles_user_id_idx": {
+          "name": "user_roles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_roles_granted_by_users_id_fk": {
+          "name": "user_roles_granted_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_unique": {
+          "name": "user_roles_user_id_role_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collected_waste_status": {
+      "name": "collected_waste_status",
+      "schema": "public",
+      "values": [
+        "collected",
+        "verified"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "reward",
+        "report_update",
+        "collection",
+        "system"
+      ]
+    },
+    "public.report_status": {
+      "name": "report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "in_progress",
+        "collected",
+        "verified",
+        "rejected"
+      ]
+    },
+    "public.transaction_kind": {
+      "name": "transaction_kind",
+      "schema": "public",
+      "values": [
+        "earned_report",
+        "earned_collect",
+        "redeemed"
+      ]
+    },
+    "public.waste_type": {
+      "name": "waste_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "plastic",
+        "organic",
+        "metal",
+        "paper",
+        "ewaste",
+        "hazardous",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781852318224,
       "tag": "0003_add_audit_log",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782288688421,
+      "tag": "0004_add_roles_rbac",
+      "breakpoints": true
     }
   ]
 }

--- a/hooks/useSession.tsx
+++ b/hooks/useSession.tsx
@@ -6,7 +6,7 @@ export interface SessionUser {
   id: number;
   email: string;
   name: string;
-  role: string;
+  roles: string[];
 }
 
 /**

--- a/lib/rbac.test.ts
+++ b/lib/rbac.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the three dependencies of rbac.ts so the tests are pure units: no DB,
+// no cookies. (These replacements also stop the real modules — which import
+// neon / next/headers — from loading.)
+vi.mock('./session', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/utils/db/internal', () => ({ getUserById: vi.fn() }));
+vi.mock('@/utils/db/roles', () => ({ getUserRoles: vi.fn() }));
+
+import { getServerSession } from './session';
+import { getUserById } from '@/utils/db/internal';
+import { getUserRoles } from '@/utils/db/roles';
+import type { Role } from '@/utils/db/schema';
+import {
+  getCurrentUser,
+  requireUser,
+  requireRole,
+  requireAnyRole,
+  requireOwnership,
+  UnauthorizedError,
+  ForbiddenError,
+} from './rbac';
+
+const mockSession = vi.mocked(getServerSession);
+const mockUserById = vi.mocked(getUserById);
+const mockRoles = vi.mocked(getUserRoles);
+
+function signedInAs(userId: number, roles: Role[]) {
+  mockSession.mockResolvedValue({ userId });
+  mockUserById.mockResolvedValue({
+    id: userId,
+    email: 'user@example.com',
+    name: 'Test User',
+    created_at: new Date(),
+  });
+  mockRoles.mockResolvedValue(roles);
+}
+
+function signedOut() {
+  mockSession.mockResolvedValue(null);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('unauthorized (401) — no session', () => {
+  it('getCurrentUser returns null', async () => {
+    signedOut();
+    expect(await getCurrentUser()).toBeNull();
+  });
+
+  it('requireUser throws UnauthorizedError', async () => {
+    signedOut();
+    await expect(requireUser()).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('requireRole throws UnauthorizedError (not Forbidden) when signed out', async () => {
+    signedOut();
+    await expect(requireRole(['admin'])).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+});
+
+describe('forbidden (403) — wrong role', () => {
+  it('requireRole rejects a citizen asking for admin', async () => {
+    signedInAs(1, ['citizen']);
+    await expect(requireRole(['admin'])).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('requireRole rejects when none of several roles match', async () => {
+    signedInAs(1, ['citizen']);
+    await expect(requireRole(['supervisor', 'admin'])).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});
+
+describe('authorized role access', () => {
+  it('requireRole returns the session user when the role matches', async () => {
+    signedInAs(42, ['admin']);
+    const user = await requireRole(['admin']);
+    expect(user.userId).toBe(42);
+    expect(user.roles).toContain('admin');
+  });
+
+  it('requireRole accepts a single (non-array) role', async () => {
+    signedInAs(5, ['supervisor']);
+    const user = await requireRole('supervisor');
+    expect(user.userId).toBe(5);
+  });
+
+  it('requireAnyRole passes when the user holds one of the listed roles', async () => {
+    signedInAs(7, ['operator']);
+    const user = await requireAnyRole(['operator', 'supervisor', 'admin']);
+    expect(user.userId).toBe(7);
+  });
+});
+
+describe('ownership checks', () => {
+  it('allows the owner', async () => {
+    signedInAs(7, ['citizen']);
+    const user = await requireOwnership(7);
+    expect(user.userId).toBe(7);
+  });
+
+  it('blocks a non-owner with no override roles', async () => {
+    signedInAs(7, ['citizen']);
+    await expect(requireOwnership(8)).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('allows a non-owner holding an allowed override role', async () => {
+    signedInAs(7, ['admin']);
+    const user = await requireOwnership(8, { allowRoles: ['admin'] });
+    expect(user.userId).toBe(7);
+  });
+
+  it('still blocks a non-owner whose role is not in allowRoles', async () => {
+    signedInAs(7, ['operator']);
+    await expect(requireOwnership(8, { allowRoles: ['admin'] })).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,0 +1,98 @@
+import { getServerSession } from './session';
+import { getUserById } from '@/utils/db/internal';
+import { getUserRoles } from '@/utils/db/roles';
+import type { Role } from '@/utils/db/schema';
+
+// KWM-009 — server-side authorization primitives.
+//
+// Every server action and route handler that touches user data derives the
+// acting identity through getCurrentUser() (which reads the signed session
+// cookie via getServerSession) and gates on roles loaded fresh from the DB.
+// Identity is therefore never taken from a client argument — this is what
+// closes audit blocker C-4.
+
+/** No (or invalid) session → maps to HTTP 401 in route handlers. */
+export class UnauthorizedError extends Error {
+  constructor(message = 'Not authenticated') {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+/** Authenticated but lacking the required role/ownership → HTTP 403. */
+export class ForbiddenError extends Error {
+  constructor(message = 'Insufficient permissions') {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export interface CurrentUser {
+  userId: number;
+  email: string;
+  name: string;
+  roles: Role[];
+}
+
+/**
+ * Resolves the current user from the session cookie, with roles loaded fresh
+ * from the database. Returns null when there is no valid session or the user no
+ * longer exists.
+ */
+export async function getCurrentUser(): Promise<CurrentUser | null> {
+  const session = await getServerSession();
+  if (!session) return null;
+
+  const user = await getUserById(session.userId);
+  if (!user) return null;
+
+  const roles = await getUserRoles(session.userId);
+  return { userId: user.id, email: user.email, name: user.name, roles };
+}
+
+/** Like getCurrentUser but throws UnauthorizedError instead of returning null. */
+export async function requireUser(): Promise<CurrentUser> {
+  const user = await getCurrentUser();
+  if (!user) throw new UnauthorizedError();
+  return user;
+}
+
+export function hasRole(user: CurrentUser, role: Role): boolean {
+  return user.roles.includes(role);
+}
+
+/**
+ * Requires the caller to hold at least one of the given role(s); otherwise
+ * throws ForbiddenError (or UnauthorizedError if not signed in). Returns the
+ * resolved CurrentUser so callers can use the session-derived userId.
+ */
+export async function requireRole(roles: Role | Role[]): Promise<CurrentUser> {
+  const allowed = Array.isArray(roles) ? roles : [roles];
+  const user = await requireUser();
+  if (!user.roles.some((r) => allowed.includes(r))) {
+    throw new ForbiddenError(`Requires one of: ${allowed.join(', ')}`);
+  }
+  return user;
+}
+
+/** Explicit "any of these roles" alias for readability at call sites. */
+export async function requireAnyRole(roles: Role[]): Promise<CurrentUser> {
+  return requireRole(roles);
+}
+
+/**
+ * Requires the caller to be the resource owner, or to hold one of opts.allowRoles
+ * (e.g. an admin acting on another user's resource). Throws ForbiddenError
+ * otherwise.
+ */
+export async function requireOwnership(
+  ownerId: number,
+  opts?: { allowRoles?: Role[] }
+): Promise<CurrentUser> {
+  const user = await requireUser();
+  if (user.userId === ownerId) return user;
+  if (opts?.allowRoles && user.roles.some((r) => opts.allowRoles!.includes(r))) {
+    return user;
+  }
+  throw new ForbiddenError('Not the resource owner');
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -10,9 +10,12 @@ export const SESSION_COOKIE = isProd ? "__Host-session" : "session";
 
 const MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
+// The session cookie is an identity anchor only: it carries the signed userId
+// and nothing else. Roles are resolved from the database on each authorization
+// check (see lib/rbac.ts) so they are never stale and a revoked grant takes
+// effect immediately — the cookie is trusted for *who*, never for *what*.
 export interface SessionPayload {
   userId: number;
-  role: string;
 }
 
 function secretKey(): Uint8Array {
@@ -24,7 +27,7 @@ function secretKey(): Uint8Array {
 }
 
 export async function createSessionToken(payload: SessionPayload): Promise<string> {
-  return new SignJWT({ userId: payload.userId, role: payload.role })
+  return new SignJWT({ userId: payload.userId })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime(`${MAX_AGE_SECONDS}s`)
@@ -38,10 +41,7 @@ export async function getServerSession(): Promise<SessionPayload | null> {
   try {
     const { payload } = await jwtVerify(token, secretKey());
     if (typeof payload.userId !== "number") return null;
-    return {
-      userId: payload.userId,
-      role: typeof payload.role === "string" ? payload.role : "citizen",
-    };
+    return { userId: payload.userId };
   } catch {
     // Tampered, expired, or wrong-secret tokens resolve to "no session".
     return null;

--- a/utils/db/actions.ts
+++ b/utils/db/actions.ts
@@ -2,38 +2,21 @@
 
 import { db } from './dbConfig';
 import { Users, Reports, Rewards, CollectedWastes, Notifications, Transactions } from './schema';
-import type { ReportStatus, WasteType, NotificationType } from './schema';
+import type { ReportStatus, WasteType, Role } from './schema';
 import { eq, sql, and, desc } from 'drizzle-orm';
+import { requireUser, requireRole, requireOwnership } from '@/lib/rbac';
+import { updateRewardPoints, createTransaction, createNotification, getOrCreateReward } from './internal';
 
-export async function createUser(email: string, name: string) {
-  try {
-    const [user] = await db.insert(Users).values({ email, name }).returning().execute();
-    return user;
-  } catch (error) {
-    console.error("Error creating user:", error);
-    return null;
-  }
-}
+// KWM-009 — every exported function here is a "use server" action, i.e. a
+// public RPC endpoint. The acting identity is ALWAYS derived from the session
+// (requireUser / requireRole / requireOwnership) and never accepted as a
+// caller-supplied argument. Privileged operations are gated by role; user
+// identities only ever appear as *targets* of an operation an authorised actor
+// performs (e.g. saveReward's recipient), never as the actor. This closes C-4.
 
-export async function getUserByEmail(email: string) {
-  try {
-    const [user] = await db.select().from(Users).where(eq(Users.email, email)).execute();
-    return user;
-  } catch (error) {
-    console.error("Error fetching user by email:", error);
-    return null;
-  }
-}
-
-export async function getUserById(id: number) {
-  try {
-    const [user] = await db.select().from(Users).where(eq(Users.id, id)).execute();
-    return user;
-  } catch (error) {
-    console.error("Error fetching user by id:", error);
-    return null;
-  }
-}
+const COLLECTION_ROLES: Role[] = ['operator', 'supervisor', 'admin'];
+const REVIEW_ROLES: Role[] = ['supervisor', 'admin'];
+const OPS_VIEW_ROLES: Role[] = ['operator', 'supervisor', 'admin'];
 
 interface VerificationResult {
   verified: boolean;
@@ -41,8 +24,17 @@ interface VerificationResult {
   details?: string;
 }
 
+interface UserReward {
+  id: number;
+  user_id: number;
+  points: number;
+  name: string;
+  isAvailable: boolean;
+}
+
+// --- Self-service: the actor is the session user ----------------------------
+
 export async function createReport(
-  userId: number,
   location: string,
   wasteType: WasteType,
   amount: string,
@@ -50,11 +42,12 @@ export async function createReport(
   type?: string,
   verificationResult?: VerificationResult
 ) {
+  const me = await requireUser();
   try {
     const [report] = await db
       .insert(Reports)
       .values({
-        user_id: userId,
+        user_id: me.userId,
         location,
         wasteType,
         amount,
@@ -65,16 +58,12 @@ export async function createReport(
       .returning()
       .execute();
 
-    // Award 10 points for reporting waste
+    // Award 10 points for reporting waste.
     const pointsEarned = 10;
-    await updateRewardPoints(userId, pointsEarned);
-
-    // Create a transaction for the earned points
-    await createTransaction(userId, 'earned_report', pointsEarned, 'Points earned for reporting waste');
-
-    // Create a notification for the user
+    await updateRewardPoints(me.userId, pointsEarned);
+    await createTransaction(me.userId, 'earned_report', pointsEarned, 'Points earned for reporting waste');
     await createNotification(
-      userId,
+      me.userId,
       `You've earned ${pointsEarned} points for reporting waste!`,
       'reward'
     );
@@ -86,60 +75,185 @@ export async function createReport(
   }
 }
 
-export async function getReportsByUserId(userId: number) {
+export async function getReportsByUserId() {
+  const me = await requireUser();
   try {
-    const reports = await db.select().from(Reports).where(eq(Reports.user_id, userId)).execute();
-    return reports;
+    return await db.select().from(Reports).where(eq(Reports.user_id, me.userId)).execute();
   } catch (error) {
     console.error("Error fetching reports:", error);
     return [];
   }
 }
 
-export async function getOrCreateReward(userId: number) {
+export async function getUnreadNotifications() {
+  const me = await requireUser();
   try {
-    let [reward] = await db.select().from(Rewards).where(eq(Rewards.user_id, userId)).execute();
-    if (!reward) {
-      [reward] = await db.insert(Rewards).values({
-        user_id: userId,
-        name: 'Default Reward',
-        collectionInfor: 'Default Collection Info',
-        points: 0,
-        isAvailable: true,
-      }).returning().execute();
-    }
-    return reward;
+    return await db.select().from(Notifications).where(
+      and(
+        eq(Notifications.userId, me.userId),
+        eq(Notifications.isRead, false)
+      )
+    ).execute();
   } catch (error) {
-    console.error("Error getting or creating reward:", error);
-    return null;
+    console.error("Error fetching unread notifications:", error);
+    return [];
   }
 }
 
-export async function updateRewardPoints(userId: number, pointsToAdd: number) {
+export async function markNotificationAsRead(notificationId: number) {
+  // Authenticate before any lookup, then enforce ownership (admins may override).
+  await requireUser();
+  const [notif] = await db
+    .select()
+    .from(Notifications)
+    .where(eq(Notifications.id, notificationId))
+    .execute();
+  if (!notif) return;
+  await requireOwnership(notif.userId, { allowRoles: ['admin'] });
   try {
-    const [updatedReward] = await db
-      .update(Rewards)
-      .set({
-        points: sql`${Rewards.points} + ${pointsToAdd}`,
-        updatedAt: new Date()
+    await db.update(Notifications).set({ isRead: true }).where(eq(Notifications.id, notificationId)).execute();
+  } catch (error) {
+    console.error("Error marking notification as read:", error);
+  }
+}
+
+export async function getRewardTransactions() {
+  const me = await requireUser();
+  try {
+    const transactions = await db
+      .select({
+        id: Transactions.id,
+        type: Transactions.type,
+        amount: Transactions.amount,
+        description: Transactions.description,
+        date: Transactions.date,
       })
-      .where(eq(Rewards.user_id, userId))
-      .returning()
+      .from(Transactions)
+      .where(eq(Transactions.userId, me.userId))
+      .orderBy(desc(Transactions.date))
+      .limit(10)
       .execute();
-    return updatedReward;
+
+    return transactions.map(t => ({
+      ...t,
+      date: t.date.toISOString().split('T')[0], // Format date as YYYY-MM-DD
+    }));
   } catch (error) {
-    console.error("Error updating reward points:", error);
-    return null;
+    console.error("Error fetching reward transactions:", error);
+    return [];
   }
 }
 
-export async function createCollectedWaste(reportId: number, collectorId: number) {
+export async function getAvailableRewards() {
+  await requireUser();
+  try {
+    // getRewardTransactions also enforces the session; identity flows from there.
+    const userTransactions = await getRewardTransactions();
+    const userPoints = userTransactions.reduce((total, transaction) => {
+      return transaction.type.startsWith('earned') ? total + transaction.amount : total - transaction.amount;
+    }, 0);
+
+    const dbRewards = await db
+      .select({
+        id: Rewards.id,
+        name: Rewards.name,
+        cost: Rewards.points,
+        description: Rewards.description,
+        collectionInfo: Rewards.collectionInfor,
+      })
+      .from(Rewards)
+      .where(eq(Rewards.isAvailable, true))
+      .execute();
+
+    return [
+      {
+        id: 0, // Special ID for the user's own points balance.
+        name: "Your Points",
+        cost: userPoints,
+        description: "Redeem your earned points",
+        collectionInfo: "Points earned from reporting and collecting waste"
+      },
+      ...dbRewards
+    ];
+  } catch (error) {
+    console.error("Error fetching available rewards:", error);
+    return [];
+  }
+}
+
+export async function getUserBalance(): Promise<number> {
+  await requireUser();
+  const transactions = await getRewardTransactions();
+  const balance = transactions.reduce((acc, transaction) => {
+    return transaction.type.startsWith('earned') ? acc + transaction.amount : acc - transaction.amount;
+  }, 0);
+  return Math.max(balance, 0); // Ensure balance is never negative.
+}
+
+export async function redeemReward(rewardId: number) {
+  const me = await requireUser();
+  try {
+    const userReward = await getOrCreateReward(me.userId) as UserReward | null;
+
+    if (rewardId === 0) {
+      // Redeem all points.
+      const [updatedReward] = await db.update(Rewards)
+        .set({ points: 0, updatedAt: new Date() })
+        .where(eq(Rewards.user_id, me.userId))
+        .returning()
+        .execute();
+
+      if (userReward) {
+        await createTransaction(me.userId, 'redeemed', userReward.points, `Redeemed all points: ${userReward.points}`);
+      }
+
+      return updatedReward;
+    } else {
+      const availableReward = await db.select().from(Rewards).where(eq(Rewards.id, rewardId)).execute();
+
+      if (!userReward || !availableReward[0] || userReward.points < availableReward[0].points) {
+        throw new Error("Insufficient points or invalid reward");
+      }
+
+      const [updatedReward] = await db.update(Rewards)
+        .set({
+          points: sql`${Rewards.points} - ${availableReward[0].points}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(Rewards.user_id, me.userId))
+        .returning()
+        .execute();
+
+      await createTransaction(me.userId, 'redeemed', availableReward[0].points, `Redeemed: ${availableReward[0].name}`);
+
+      return updatedReward;
+    }
+  } catch (error) {
+    console.error("Error redeeming reward:", error);
+    throw error;
+  }
+}
+
+// --- Operator / collection: requires a collection role; collector = session --
+
+export async function getCollectedWastesByCollector() {
+  const me = await requireRole(COLLECTION_ROLES);
+  try {
+    return await db.select().from(CollectedWastes).where(eq(CollectedWastes.collectorId, me.userId)).execute();
+  } catch (error) {
+    console.error("Error fetching collected wastes:", error);
+    return [];
+  }
+}
+
+export async function createCollectedWaste(reportId: number) {
+  const me = await requireRole(COLLECTION_ROLES);
   try {
     const [collectedWaste] = await db
       .insert(CollectedWastes)
       .values({
         reportId,
-        collectorId,
+        collectorId: me.userId,
         collectionDate: new Date(),
       })
       .returning()
@@ -151,52 +265,74 @@ export async function createCollectedWaste(reportId: number, collectorId: number
   }
 }
 
-export async function getCollectedWastesByCollector(collectorId: number) {
+export async function saveCollectedWaste(reportId: number) {
+  const me = await requireRole(COLLECTION_ROLES);
   try {
-    return await db.select().from(CollectedWastes).where(eq(CollectedWastes.collectorId, collectorId)).execute();
-  } catch (error) {
-    console.error("Error fetching collected wastes:", error);
-    return [];
-  }
-}
-
-export async function createNotification(userId: number, message: string, type: NotificationType) {
-  try {
-    const [notification] = await db
-      .insert(Notifications)
-      .values({ userId, message, type })
+    const [collectedWaste] = await db
+      .insert(CollectedWastes)
+      .values({
+        reportId,
+        collectorId: me.userId,
+        collectionDate: new Date(),
+        status: 'verified',
+      })
       .returning()
       .execute();
-    return notification;
+    return collectedWaste;
   } catch (error) {
-    console.error("Error creating notification:", error);
-    return null;
+    console.error("Error saving collected waste:", error);
+    throw error;
   }
 }
 
-export async function getUnreadNotifications(userId: number) {
+export async function updateTaskStatus(reportId: number, newStatus: ReportStatus) {
+  // The acting operator claims the task; collector is the session user, never a
+  // caller-supplied id.
+  const me = await requireRole(COLLECTION_ROLES);
   try {
-    return await db.select().from(Notifications).where(
-      and(
-        eq(Notifications.userId, userId),
-        eq(Notifications.isRead, false)
-      )
-    ).execute();
+    const [updatedReport] = await db
+      .update(Reports)
+      .set({ status: newStatus, collector_id: me.userId })
+      .where(eq(Reports.id, reportId))
+      .returning()
+      .execute();
+    return updatedReport;
   } catch (error) {
-    console.error("Error fetching unread notifications:", error);
-    return [];
+    console.error("Error updating task status:", error);
+    throw error;
   }
 }
 
-export async function markNotificationAsRead(notificationId: number) {
+// saveReward awards points to a *recipient* (a reporter) — the actor is an
+// authorised operator/admin resolved from the session, not the recipient.
+export async function saveReward(recipientUserId: number, amount: number) {
+  await requireRole(COLLECTION_ROLES);
   try {
-    await db.update(Notifications).set({ isRead: true }).where(eq(Notifications.id, notificationId)).execute();
+    const [reward] = await db
+      .insert(Rewards)
+      .values({
+        user_id: recipientUserId,
+        name: 'Waste Collection Reward',
+        collectionInfor: 'Points earned from waste collection',
+        points: amount,
+        isAvailable: true,
+      })
+      .returning()
+      .execute();
+
+    await createTransaction(recipientUserId, 'earned_collect', amount, 'Points earned for collecting waste');
+
+    return reward;
   } catch (error) {
-    console.error("Error marking notification as read:", error);
+    console.error("Error saving reward:", error);
+    throw error;
   }
 }
+
+// --- Review / oversight: supervisor or admin --------------------------------
 
 export async function getPendingReports() {
+  await requireRole(REVIEW_ROLES);
   try {
     return await db.select().from(Reports).where(eq(Reports.status, "pending")).execute();
   } catch (error) {
@@ -206,6 +342,7 @@ export async function getPendingReports() {
 }
 
 export async function updateReportStatus(reportId: number, status: ReportStatus) {
+  await requireRole(REVIEW_ROLES);
   try {
     const [updatedReport] = await db
       .update(Reports)
@@ -220,15 +357,38 @@ export async function updateReportStatus(reportId: number, status: ReportStatus)
   }
 }
 
-export async function getRecentReports(limit: number = 10) {
+export async function getAllRewards() {
+  await requireRole(REVIEW_ROLES);
   try {
-    const reports = await db
+    return await db
+      .select({
+        id: Rewards.id,
+        userId: Rewards.user_id,
+        points: Rewards.points,
+        createdAt: Rewards.createdAt,
+        userName: Users.name,
+      })
+      .from(Rewards)
+      .leftJoin(Users, eq(Rewards.user_id, Users.id))
+      .orderBy(desc(Rewards.points))
+      .execute();
+  } catch (error) {
+    console.error("Error fetching all rewards:", error);
+    return [];
+  }
+}
+
+// --- Operations views: any collection role ----------------------------------
+
+export async function getRecentReports(limit: number = 10) {
+  await requireRole(OPS_VIEW_ROLES);
+  try {
+    return await db
       .select()
       .from(Reports)
       .orderBy(desc(Reports.created_at))
       .limit(limit)
       .execute();
-    return reports;
   } catch (error) {
     console.error("Error fetching recent reports:", error);
     return [];
@@ -236,6 +396,7 @@ export async function getRecentReports(limit: number = 10) {
 }
 
 export async function getWasteCollectionTasks(limit: number = 20) {
+  await requireRole(OPS_VIEW_ROLES);
   try {
     const tasks = await db
       .select({
@@ -259,246 +420,4 @@ export async function getWasteCollectionTasks(limit: number = 20) {
     console.error("Error fetching waste collection tasks:", error);
     return [];
   }
-}
-
-export async function saveReward(userId: number, amount: number) {
-  try {
-    const [reward] = await db
-      .insert(Rewards)
-      .values({
-        user_id: userId,
-        name: 'Waste Collection Reward',
-        collectionInfor: 'Points earned from waste collection',
-        points: amount,
-        isAvailable: true,
-      })
-      .returning()
-      .execute();
-
-    // Create a transaction for this reward
-    await createTransaction(userId, 'earned_collect', amount, 'Points earned for collecting waste');
-
-    return reward;
-  } catch (error) {
-    console.error("Error saving reward:", error);
-    throw error;
-  }
-}
-
-export async function saveCollectedWaste(reportId: number, collectorId: number) {
-  try {
-    const [collectedWaste] = await db
-      .insert(CollectedWastes)
-      .values({
-        reportId,
-        collectorId,
-        collectionDate: new Date(),
-        status: 'verified',
-      })
-      .returning()
-      .execute();
-    return collectedWaste;
-  } catch (error) {
-    console.error("Error saving collected waste:", error);
-    throw error;
-  }
-}
-
-export async function updateTaskStatus(reportId: number, newStatus: ReportStatus, collectorId?: number) {
-  try {
-    const updateData: { status: ReportStatus; collector_id?: number } = { status: newStatus };
-    if (collectorId !== undefined) {
-      updateData.collector_id = collectorId;
-    }
-    const [updatedReport] = await db
-      .update(Reports)
-      .set(updateData)
-      .where(eq(Reports.id, reportId))
-      .returning()
-      .execute();
-    return updatedReport;
-  } catch (error) {
-    console.error("Error updating task status:", error);
-    throw error;
-  }
-}
-
-export async function getAllRewards() {
-  try {
-    const rewards = await db
-      .select({
-        id: Rewards.id,
-        userId: Rewards.user_id,
-        points: Rewards.points,
-        createdAt: Rewards.createdAt,
-        userName: Users.name,
-      })
-      .from(Rewards)
-      .leftJoin(Users, eq(Rewards.user_id, Users.id))
-      .orderBy(desc(Rewards.points))
-      .execute();
-
-    return rewards;
-  } catch (error) {
-    console.error("Error fetching all rewards:", error);
-    return [];
-  }
-}
-
-export async function getRewardTransactions(userId: number) {
-  try {
-    console.log('Fetching transactions for user ID:', userId)
-    const transactions = await db
-      .select({
-        id: Transactions.id,
-        type: Transactions.type,
-        amount: Transactions.amount,
-        description: Transactions.description,
-        date: Transactions.date,
-      })
-      .from(Transactions)
-      .where(eq(Transactions.userId, userId))
-      .orderBy(desc(Transactions.date))
-      .limit(10)
-      .execute();
-
-    console.log('Raw transactions from database:', transactions)
-
-    const formattedTransactions = transactions.map(t => ({
-      ...t,
-      date: t.date.toISOString().split('T')[0], // Format date as YYYY-MM-DD
-    }));
-
-    console.log('Formatted transactions:', formattedTransactions)
-    return formattedTransactions;
-  } catch (error) {
-    console.error("Error fetching reward transactions:", error);
-    return [];
-  }
-}
-
-export async function getAvailableRewards(userId: number) {
-  try {
-    console.log('Fetching available rewards for user:', userId);
-    
-    // Get user's total points
-    const userTransactions = await getRewardTransactions(userId);
-    const userPoints = userTransactions.reduce((total, transaction) => {
-      return transaction.type.startsWith('earned') ? total + transaction.amount : total - transaction.amount;
-    }, 0);
-
-    console.log('User total points:', userPoints);
-
-    // Get available rewards from the database
-    const dbRewards = await db
-      .select({
-        id: Rewards.id,
-        name: Rewards.name,
-        cost: Rewards.points,
-        description: Rewards.description,
-        collectionInfo: Rewards.collectionInfor,
-      })
-      .from(Rewards)
-      .where(eq(Rewards.isAvailable, true))
-      .execute();
-
-    console.log('Rewards from database:', dbRewards);
-
-    // Combine user points and database rewards
-    const allRewards = [
-      {
-        id: 0, // Use a special ID for user's points
-        name: "Your Points",
-        cost: userPoints,
-        description: "Redeem your earned points",
-        collectionInfo: "Points earned from reporting and collecting waste"
-      },
-      ...dbRewards
-    ];
-
-    console.log('All available rewards:', allRewards);
-    return allRewards;
-  } catch (error) {
-    console.error("Error fetching available rewards:", error);
-    return [];
-  }
-}
-
-export async function createTransaction(userId: number, type: 'earned_report' | 'earned_collect' | 'redeemed', amount: number, description: string) {
-  try {
-    const [transaction] = await db
-      .insert(Transactions)
-      .values({ userId, type, amount, description })
-      .returning()
-      .execute();
-    return transaction;
-  } catch (error) {
-    console.error("Error creating transaction:", error);
-    throw error;
-  }
-}
-
-interface UserReward {
-  id: number;
-  user_id: number;
-  points: number;
-  name: string;
-  isAvailable: boolean;
-}
-
-export async function redeemReward(userId: number, rewardId: number) {
-  try {
-    const userReward = await getOrCreateReward(userId) as UserReward | null;
-
-    if (rewardId === 0) {
-      // Redeem all points
-      const [updatedReward] = await db.update(Rewards)
-        .set({
-          points: 0,
-          updatedAt: new Date(),
-        })
-        .where(eq(Rewards.user_id, userId))
-        .returning()
-        .execute();
-
-      // Create a transaction for this redemption
-      if (userReward) {
-        await createTransaction(userId, 'redeemed', userReward.points, `Redeemed all points: ${userReward.points}`);
-      }
-
-      return updatedReward;
-    } else {
-      // Existing logic for redeeming specific rewards
-      const availableReward = await db.select().from(Rewards).where(eq(Rewards.id, rewardId)).execute();
-
-      if (!userReward || !availableReward[0] || userReward.points < availableReward[0].points) {
-        throw new Error("Insufficient points or invalid reward");
-      }
-
-      const [updatedReward] = await db.update(Rewards)
-        .set({
-          points: sql`${Rewards.points} - ${availableReward[0].points}`,
-          updatedAt: new Date(),
-        })
-        .where(eq(Rewards.user_id, userId))
-        .returning()
-        .execute();
-
-      // Create a transaction for this redemption
-      await createTransaction(userId, 'redeemed', availableReward[0].points, `Redeemed: ${availableReward[0].name}`);
-
-      return updatedReward;
-    }
-  } catch (error) {
-    console.error("Error redeeming reward:", error);
-    throw error;
-  }
-}
-
-export async function getUserBalance(userId: number): Promise<number> {
-  const transactions = await getRewardTransactions(userId);
-  const balance = transactions.reduce((acc, transaction) => {
-    return transaction.type.startsWith('earned') ? acc + transaction.amount : acc - transaction.amount
-  }, 0);
-  return Math.max(balance, 0); // Ensure balance is never negative
 }

--- a/utils/db/internal.ts
+++ b/utils/db/internal.ts
@@ -1,0 +1,109 @@
+import { db } from './dbConfig';
+import { Users, Rewards, Notifications, Transactions } from './schema';
+import type { NotificationType } from './schema';
+import { eq, sql } from 'drizzle-orm';
+
+// KWM-009 — internal data-layer helpers.
+//
+// This is deliberately NOT a "use server" module. Anything exported from a
+// "use server" file becomes a client-invokable RPC endpoint; these functions
+// mint points, write ledger rows, create users, and look up identities, so they
+// must never be directly reachable from the client. They are imported only by
+// trusted server code: the auth routes, the RBAC resolver, and the guarded
+// actions in actions.ts. Keeping them off the action surface is part of closing
+// audit blocker C-4.
+
+export async function createUser(email: string, name: string) {
+  try {
+    const [user] = await db.insert(Users).values({ email, name }).returning().execute();
+    return user;
+  } catch (error) {
+    console.error("Error creating user:", error);
+    return null;
+  }
+}
+
+export async function getUserByEmail(email: string) {
+  try {
+    const [user] = await db.select().from(Users).where(eq(Users.email, email)).execute();
+    return user;
+  } catch (error) {
+    console.error("Error fetching user by email:", error);
+    return null;
+  }
+}
+
+export async function getUserById(id: number) {
+  try {
+    const [user] = await db.select().from(Users).where(eq(Users.id, id)).execute();
+    return user;
+  } catch (error) {
+    console.error("Error fetching user by id:", error);
+    return null;
+  }
+}
+
+export async function getOrCreateReward(userId: number) {
+  try {
+    let [reward] = await db.select().from(Rewards).where(eq(Rewards.user_id, userId)).execute();
+    if (!reward) {
+      [reward] = await db.insert(Rewards).values({
+        user_id: userId,
+        name: 'Default Reward',
+        collectionInfor: 'Default Collection Info',
+        points: 0,
+        isAvailable: true,
+      }).returning().execute();
+    }
+    return reward;
+  } catch (error) {
+    console.error("Error getting or creating reward:", error);
+    return null;
+  }
+}
+
+export async function updateRewardPoints(userId: number, pointsToAdd: number) {
+  try {
+    const [updatedReward] = await db
+      .update(Rewards)
+      .set({
+        points: sql`${Rewards.points} + ${pointsToAdd}`,
+        updatedAt: new Date()
+      })
+      .where(eq(Rewards.user_id, userId))
+      .returning()
+      .execute();
+    return updatedReward;
+  } catch (error) {
+    console.error("Error updating reward points:", error);
+    return null;
+  }
+}
+
+export async function createTransaction(userId: number, type: 'earned_report' | 'earned_collect' | 'redeemed', amount: number, description: string) {
+  try {
+    const [transaction] = await db
+      .insert(Transactions)
+      .values({ userId, type, amount, description })
+      .returning()
+      .execute();
+    return transaction;
+  } catch (error) {
+    console.error("Error creating transaction:", error);
+    throw error;
+  }
+}
+
+export async function createNotification(userId: number, message: string, type: NotificationType) {
+  try {
+    const [notification] = await db
+      .insert(Notifications)
+      .values({ userId, message, type })
+      .returning()
+      .execute();
+    return notification;
+  } catch (error) {
+    console.error("Error creating notification:", error);
+    return null;
+  }
+}

--- a/utils/db/roles.ts
+++ b/utils/db/roles.ts
@@ -1,0 +1,42 @@
+import { db } from './dbConfig';
+import { Roles, UserRoles } from './schema';
+import type { Role } from './schema';
+import { eq } from 'drizzle-orm';
+
+// KWM-008 — role read/grant helpers. Plain module (NOT "use server"): called
+// only from trusted server code (the auth route assigns the default role; the
+// RBAC resolver reads roles). Roles are resolved from the DB on each check so a
+// revoked grant takes effect immediately — the session cookie is never trusted
+// for authorization, only for identity.
+
+/** Returns the role names granted to a user (empty array if none). */
+export async function getUserRoles(userId: number): Promise<Role[]> {
+  const rows = await db
+    .select({ name: Roles.name })
+    .from(UserRoles)
+    .innerJoin(Roles, eq(UserRoles.roleId, Roles.id))
+    .where(eq(UserRoles.userId, userId))
+    .execute();
+  return rows.map((r) => r.name as Role);
+}
+
+/** Grants a role to a user. Idempotent: re-granting the same role is a no-op. */
+export async function assignRole(
+  userId: number,
+  roleName: Role,
+  grantedBy?: number
+): Promise<void> {
+  const [role] = await db
+    .select({ id: Roles.id })
+    .from(Roles)
+    .where(eq(Roles.name, roleName))
+    .execute();
+  if (!role) {
+    throw new Error(`Unknown role: ${roleName}`);
+  }
+  await db
+    .insert(UserRoles)
+    .values({ userId, roleId: role.id, grantedBy: grantedBy ?? null })
+    .onConflictDoNothing()
+    .execute();
+}

--- a/utils/db/schema.ts
+++ b/utils/db/schema.ts
@@ -1,4 +1,4 @@
-import {integer, varchar, pgTable,serial,text, jsonb, timestamp,boolean, index, pgEnum} from 'drizzle-orm/pg-core';
+import {integer, varchar, pgTable,serial,text, jsonb, timestamp,boolean, index, pgEnum, unique} from 'drizzle-orm/pg-core';
 
 // ---------------------------------------------------------------------------
 // Enums (KWM-015) — replace free-text status/type columns with constrained
@@ -118,4 +118,31 @@ export const AuditLog = pgTable('audit_log', {
     createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
     actorCreatedAtIdx: index('audit_log_actor_user_id_created_at_idx').on(table.actorUserId, table.createdAt),
+}));
+
+// ---------------------------------------------------------------------------
+// RBAC (KWM-008) — normalised roles. `roles` is a seeded catalog; `user_roles`
+// is the many-to-many grant table carrying an audit trail (granted_at /
+// granted_by). Role *names* are the source of truth for authorization; the
+// canonical set is ROLE_NAMES, seeded by migration 0004.
+// ---------------------------------------------------------------------------
+export const ROLE_NAMES = ['citizen', 'operator', 'supervisor', 'admin', 'dump_op'] as const;
+export type Role = (typeof ROLE_NAMES)[number];
+
+export const Roles = pgTable('roles', {
+    id: serial('id').primaryKey(),
+    name: varchar('name', { length: 50 }).notNull().unique(),
+    description: text('description'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const UserRoles = pgTable('user_roles', {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').notNull().references(() => Users.id, { onDelete: 'cascade' }),
+    roleId: integer('role_id').notNull().references(() => Roles.id, { onDelete: 'restrict' }),
+    grantedAt: timestamp('granted_at').defaultNow().notNull(),
+    grantedBy: integer('granted_by').references(() => Users.id, { onDelete: 'set null' }),
+}, (table) => ({
+    userIdIdx: index('user_roles_user_id_idx').on(table.userId),
+    userRoleUnique: unique('user_roles_user_id_role_id_unique').on(table.userId, table.roleId),
 }));


### PR DESCRIPTION
 ## KWM-008 + KWM-009 — RBAC and session-derived identity (closes audit blocker C-4)

  Establishes normalised RBAC and enforces it at every server-action boundary.
  Identity is now derived exclusively from the signed session cookie; no action
  accepts a caller-supplied actor id.

  ### KWM-008 — roles
  - `roles` (seeded: citizen, operator, supervisor, admin, dump_op) + `user_roles`
    (many-to-many, granted_at/granted_by audit trail).
  - Migration `0004_add_roles_rbac.sql`: tables + idempotent seed + backfill of all
    existing users to `citizen`.
  - New users assigned `citizen` on signup; `/api/auth/me` returns `roles[]`.

  ### KWM-009 — enforcement
  - `lib/rbac.ts`: `getCurrentUser`, `requireUser`, `requireRole`, `requireAnyRole`,
    `requireOwnership`, `UnauthorizedError`(401)/`ForbiddenError`(403).
  - Session JWT reduced to identity-only `{ userId }`; roles resolved fresh from DB.
  - All 18 server actions derive the actor from the session; 11 actor-id params
    removed; 7 identity/ledger helpers moved off the `"use server"` surface into
    `utils/db/internal.ts` (no longer client-invokable).
  - `Header.tsx` consumes `useSession` + no-arg actions (no client-id passing).

  ### Tests
  - `lib/rbac.test.ts` — 401 / 403 / authorized-role / ownership (12 cases). CI runs
    via the KWM-061 workflow.

  ### Validation
  - Migration applied to the Neon branch; 5 roles seeded; existing user backfilled.
  - DB + HTTP smoke green (signed-cookie path resolves roles; tampered cookie and
    forged Web3Auth idToken rejected). `npm test` 13/13, lint, typecheck, build pass.
    
    closes #15 
closes #16 
closes #71 
closes #95 