### PR TITLE
feat(validation): Zod validation at every action boundary (KWM-017)

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -3,6 +3,8 @@ import { verifyWeb3AuthToken } from "@/lib/web3auth";
 import { createSessionToken, setSessionCookie } from "@/lib/session";
 import { getUserByEmail, createUser } from "@/utils/db/internal";
 import { assignRole } from "@/utils/db/roles";
+import { validate, ValidationError } from "@/lib/validation";
+import { sessionRequestSchema } from "@/utils/db/schemas";
 
 export async function POST(req: Request) {
   let body: unknown;
@@ -12,9 +14,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const idToken = (body as { idToken?: unknown })?.idToken;
-  if (!idToken || typeof idToken !== "string") {
-    return NextResponse.json({ error: "Missing idToken" }, { status: 400 });
+  let idToken: string;
+  try {
+    idToken = validate(sessionRequestSchema, body).idToken;
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
   }
 
   let claims;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,35 @@
+import { z, ZodError } from 'zod';
+
+// KWM-017 — shared validation layer.
+//
+// `ValidationError` is the third member of the action-boundary error taxonomy
+// (alongside UnauthorizedError / ForbiddenError in lib/rbac.ts). Server actions
+// validate their inputs *after* the auth guard and throw this on bad input; the
+// thrown error rejects the action promise so the UI can surface a toast.
+// KWM-019 will map this to a typed Result `{ ok:false, code:'VALIDATION', … }`.
+export class ValidationError extends Error {
+  readonly issues: { path: string; message: string }[];
+
+  constructor(error: ZodError) {
+    const issues = error.issues.map((i) => ({
+      path: i.path.join('.') || '(root)',
+      message: i.message,
+    }));
+    super(issues.map((i) => `${i.path}: ${i.message}`).join('; ') || 'Invalid input');
+    this.name = 'ValidationError';
+    this.issues = issues;
+  }
+}
+
+/**
+ * Parses `input` with `schema`, returning the typed value. Throws
+ * `ValidationError` (not a raw ZodError) on failure so callers have one error
+ * type to catch.
+ */
+export function validate<T extends z.ZodType>(schema: T, input: unknown): z.infer<T> {
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new ValidationError(result.error);
+  }
+  return result.data;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.4.1",
         "tailwind-merge": "^2.5.5",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -11382,6 +11383,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^2.5.5",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/utils/db/actions.ts
+++ b/utils/db/actions.ts
@@ -6,6 +6,18 @@ import type { ReportStatus, WasteType, Role } from './schema';
 import { eq, sql, and, desc } from 'drizzle-orm';
 import { requireUser, requireRole, requireOwnership } from '@/lib/rbac';
 import { updateRewardPoints, createTransaction, createNotification, getOrCreateReward } from './internal';
+import { validate } from '@/lib/validation';
+import {
+  createReportSchema,
+  updateReportStatusSchema,
+  updateTaskStatusSchema,
+  recentReportsSchema,
+  wasteCollectionTasksSchema,
+  redeemRewardSchema,
+  saveRewardSchema,
+  collectedWasteSchema,
+  markNotificationReadSchema,
+} from './schemas';
 
 // KWM-009 — every exported function here is a "use server" action, i.e. a
 // public RPC endpoint. The acting identity is ALWAYS derived from the session
@@ -17,12 +29,6 @@ import { updateRewardPoints, createTransaction, createNotification, getOrCreateR
 const COLLECTION_ROLES: Role[] = ['operator', 'supervisor', 'admin'];
 const REVIEW_ROLES: Role[] = ['supervisor', 'admin'];
 const OPS_VIEW_ROLES: Role[] = ['operator', 'supervisor', 'admin'];
-
-interface VerificationResult {
-  verified: boolean;
-  confidence?: number;
-  details?: string;
-}
 
 interface UserReward {
   id: number;
@@ -38,21 +44,22 @@ export async function createReport(
   location: string,
   wasteType: WasteType,
   amount: string,
-  imageUrl?: string,
-  type?: string,
-  verificationResult?: VerificationResult
+  imageUrl?: string
 ) {
   const me = await requireUser();
+  const input = validate(createReportSchema, { location, wasteType, amount, imageUrl });
   try {
     const [report] = await db
       .insert(Reports)
       .values({
         user_id: me.userId,
-        location,
-        wasteType,
-        amount,
-        imageUrl,
-        verificationResult,
+        location: input.location,
+        wasteType: input.wasteType,
+        amount: input.amount,
+        imageUrl: input.imageUrl,
+        // Set server-side (pending) — the AI verdict is never client-trusted;
+        // trusted verification arrives in KWM-043.
+        verificationResult: null,
         status: "pending",
       })
       .returning()
@@ -103,15 +110,16 @@ export async function getUnreadNotifications() {
 export async function markNotificationAsRead(notificationId: number) {
   // Authenticate before any lookup, then enforce ownership (admins may override).
   await requireUser();
+  const { notificationId: id } = validate(markNotificationReadSchema, { notificationId });
   const [notif] = await db
     .select()
     .from(Notifications)
-    .where(eq(Notifications.id, notificationId))
+    .where(eq(Notifications.id, id))
     .execute();
   if (!notif) return;
   await requireOwnership(notif.userId, { allowRoles: ['admin'] });
   try {
-    await db.update(Notifications).set({ isRead: true }).where(eq(Notifications.id, notificationId)).execute();
+    await db.update(Notifications).set({ isRead: true }).where(eq(Notifications.id, id)).execute();
   } catch (error) {
     console.error("Error marking notification as read:", error);
   }
@@ -192,10 +200,11 @@ export async function getUserBalance(): Promise<number> {
 
 export async function redeemReward(rewardId: number) {
   const me = await requireUser();
+  const { rewardId: id } = validate(redeemRewardSchema, { rewardId });
   try {
     const userReward = await getOrCreateReward(me.userId) as UserReward | null;
 
-    if (rewardId === 0) {
+    if (id === 0) {
       // Redeem all points.
       const [updatedReward] = await db.update(Rewards)
         .set({ points: 0, updatedAt: new Date() })
@@ -209,7 +218,7 @@ export async function redeemReward(rewardId: number) {
 
       return updatedReward;
     } else {
-      const availableReward = await db.select().from(Rewards).where(eq(Rewards.id, rewardId)).execute();
+      const availableReward = await db.select().from(Rewards).where(eq(Rewards.id, id)).execute();
 
       if (!userReward || !availableReward[0] || userReward.points < availableReward[0].points) {
         throw new Error("Insufficient points or invalid reward");
@@ -248,11 +257,12 @@ export async function getCollectedWastesByCollector() {
 
 export async function createCollectedWaste(reportId: number) {
   const me = await requireRole(COLLECTION_ROLES);
+  const { reportId: id } = validate(collectedWasteSchema, { reportId });
   try {
     const [collectedWaste] = await db
       .insert(CollectedWastes)
       .values({
-        reportId,
+        reportId: id,
         collectorId: me.userId,
         collectionDate: new Date(),
       })
@@ -267,11 +277,12 @@ export async function createCollectedWaste(reportId: number) {
 
 export async function saveCollectedWaste(reportId: number) {
   const me = await requireRole(COLLECTION_ROLES);
+  const { reportId: id } = validate(collectedWasteSchema, { reportId });
   try {
     const [collectedWaste] = await db
       .insert(CollectedWastes)
       .values({
-        reportId,
+        reportId: id,
         collectorId: me.userId,
         collectionDate: new Date(),
         status: 'verified',
@@ -289,11 +300,12 @@ export async function updateTaskStatus(reportId: number, newStatus: ReportStatus
   // The acting operator claims the task; collector is the session user, never a
   // caller-supplied id.
   const me = await requireRole(COLLECTION_ROLES);
+  const input = validate(updateTaskStatusSchema, { reportId, newStatus });
   try {
     const [updatedReport] = await db
       .update(Reports)
-      .set({ status: newStatus, collector_id: me.userId })
-      .where(eq(Reports.id, reportId))
+      .set({ status: input.newStatus, collector_id: me.userId })
+      .where(eq(Reports.id, input.reportId))
       .returning()
       .execute();
     return updatedReport;
@@ -307,20 +319,21 @@ export async function updateTaskStatus(reportId: number, newStatus: ReportStatus
 // authorised operator/admin resolved from the session, not the recipient.
 export async function saveReward(recipientUserId: number, amount: number) {
   await requireRole(COLLECTION_ROLES);
+  const input = validate(saveRewardSchema, { recipientUserId, amount });
   try {
     const [reward] = await db
       .insert(Rewards)
       .values({
-        user_id: recipientUserId,
+        user_id: input.recipientUserId,
         name: 'Waste Collection Reward',
         collectionInfor: 'Points earned from waste collection',
-        points: amount,
+        points: input.amount,
         isAvailable: true,
       })
       .returning()
       .execute();
 
-    await createTransaction(recipientUserId, 'earned_collect', amount, 'Points earned for collecting waste');
+    await createTransaction(input.recipientUserId, 'earned_collect', input.amount, 'Points earned for collecting waste');
 
     return reward;
   } catch (error) {
@@ -343,11 +356,12 @@ export async function getPendingReports() {
 
 export async function updateReportStatus(reportId: number, status: ReportStatus) {
   await requireRole(REVIEW_ROLES);
+  const input = validate(updateReportStatusSchema, { reportId, status });
   try {
     const [updatedReport] = await db
       .update(Reports)
-      .set({ status })
-      .where(eq(Reports.id, reportId))
+      .set({ status: input.status })
+      .where(eq(Reports.id, input.reportId))
       .returning()
       .execute();
     return updatedReport;
@@ -382,12 +396,13 @@ export async function getAllRewards() {
 
 export async function getRecentReports(limit: number = 10) {
   await requireRole(OPS_VIEW_ROLES);
+  const { limit: lim } = validate(recentReportsSchema, { limit });
   try {
     return await db
       .select()
       .from(Reports)
       .orderBy(desc(Reports.created_at))
-      .limit(limit)
+      .limit(lim)
       .execute();
   } catch (error) {
     console.error("Error fetching recent reports:", error);
@@ -397,6 +412,7 @@ export async function getRecentReports(limit: number = 10) {
 
 export async function getWasteCollectionTasks(limit: number = 20) {
   await requireRole(OPS_VIEW_ROLES);
+  const { limit: lim } = validate(wasteCollectionTasksSchema, { limit });
   try {
     const tasks = await db
       .select({
@@ -409,7 +425,7 @@ export async function getWasteCollectionTasks(limit: number = 20) {
         collectorId: Reports.collector_id,
       })
       .from(Reports)
-      .limit(limit)
+      .limit(lim)
       .execute();
 
     return tasks.map(task => ({

--- a/utils/db/schemas/auth.ts
+++ b/utils/db/schemas/auth.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+// KWM-017 — request body schema for POST /api/auth/session.
+export const sessionRequestSchema = z.object({
+  idToken: z.string().trim().min(1).max(4096),
+});

--- a/utils/db/schemas/collection.ts
+++ b/utils/db/schemas/collection.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import { idSchema } from './common';
+
+// KWM-017 — shared by createCollectedWaste and saveCollectedWaste.
+export const collectedWasteSchema = z.object({ reportId: idSchema });

--- a/utils/db/schemas/common.ts
+++ b/utils/db/schemas/common.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { wasteTypeEnum, reportStatusEnum } from '../schema';
+
+// KWM-017 — shared validation primitives. Enum schemas are derived from the
+// drizzle pgEnums (single source of truth) so they cannot drift from the DB.
+
+// Temporary per-grant points cap (KWM-017). No business rule for reward sizing
+// exists yet; `createReport` mints a fixed 10 and realistic collection rewards
+// are tens-to-hundreds of points, so 10_000 is generous headroom while still
+// blocking absurd/typo/abuse grants (e.g. an operator minting millions). Revisit
+// when KWM-011 introduces the canonical point-transaction ledger + business rules.
+export const MAX_POINTS = 10_000;
+
+export const idSchema = z.number().int().positive();
+export const rewardIdSchema = z.number().int().nonnegative(); // 0 = redeem-all sentinel
+export const limitSchema = z.number().int().positive().max(100);
+export const pointsAmountSchema = z.number().int().positive().max(MAX_POINTS);
+
+export const wasteTypeSchema = z.enum(wasteTypeEnum.enumValues);
+export const reportStatusSchema = z.enum(reportStatusEnum.enumValues);
+
+export const locationSchema = z.string().trim().min(1).max(500);
+
+// Reported waste quantity is stored as varchar; require a positive numeric string
+// without changing the column (no migration in KWM-017).
+export const amountSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(50)
+  .refine((v) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0;
+  }, { message: 'amount must be a positive number' });
+
+// Version-agnostic https URL check (avoids zod v3/v4 `.url()` API differences).
+export const imageUrlSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(2048)
+  .refine((v) => {
+    try {
+      return new URL(v).protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }, { message: 'imageUrl must be a valid https URL' });

--- a/utils/db/schemas/index.ts
+++ b/utils/db/schemas/index.ts
@@ -1,0 +1,7 @@
+// KWM-017 — barrel for the validation schemas.
+export * from './common';
+export * from './reports';
+export * from './rewards';
+export * from './collection';
+export * from './notifications';
+export * from './auth';

--- a/utils/db/schemas/notifications.ts
+++ b/utils/db/schemas/notifications.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import { idSchema } from './common';
+
+// KWM-017 — notification action input schema.
+export const markNotificationReadSchema = z.object({ notificationId: idSchema });

--- a/utils/db/schemas/reports.ts
+++ b/utils/db/schemas/reports.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import {
+  idSchema,
+  limitSchema,
+  locationSchema,
+  amountSchema,
+  imageUrlSchema,
+  wasteTypeSchema,
+  reportStatusSchema,
+} from './common';
+
+// KWM-017 — report action input schemas.
+//
+// createReport no longer accepts `verificationResult` or the unused `type`
+// param: the AI verdict must not be client-trusted (it is set server-side as
+// pending until KWM-043 introduces trusted verification).
+export const createReportSchema = z.object({
+  location: locationSchema,
+  wasteType: wasteTypeSchema,
+  amount: amountSchema,
+  imageUrl: imageUrlSchema.optional(),
+});
+
+export const updateReportStatusSchema = z.object({
+  reportId: idSchema,
+  status: reportStatusSchema,
+});
+
+export const updateTaskStatusSchema = z.object({
+  reportId: idSchema,
+  newStatus: reportStatusSchema,
+});
+
+export const recentReportsSchema = z.object({ limit: limitSchema });
+export const wasteCollectionTasksSchema = z.object({ limit: limitSchema });

--- a/utils/db/schemas/rewards.ts
+++ b/utils/db/schemas/rewards.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { idSchema, rewardIdSchema, pointsAmountSchema } from './common';
+
+// KWM-017 — reward action input schemas.
+export const redeemRewardSchema = z.object({ rewardId: rewardIdSchema });
+
+// `amount` is the points granted to the recipient; capped by pointsAmountSchema.
+export const saveRewardSchema = z.object({
+  recipientUserId: idSchema,
+  amount: pointsAmountSchema,
+});

--- a/utils/db/schemas/schemas.test.ts
+++ b/utils/db/schemas/schemas.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+import { validate, ValidationError } from '@/lib/validation';
+import {
+  MAX_POINTS,
+  createReportSchema,
+  updateReportStatusSchema,
+  updateTaskStatusSchema,
+  recentReportsSchema,
+  wasteCollectionTasksSchema,
+  redeemRewardSchema,
+  saveRewardSchema,
+  collectedWasteSchema,
+  markNotificationReadSchema,
+  sessionRequestSchema,
+} from './index';
+
+const ok = (schema: Parameters<typeof validate>[0], input: unknown) =>
+  expect(schema.safeParse(input).success).toBe(true);
+const bad = (schema: Parameters<typeof validate>[0], input: unknown) =>
+  expect(schema.safeParse(input).success).toBe(false);
+
+describe('createReportSchema', () => {
+  const valid = { location: 'Kiteezi zone 4', wasteType: 'plastic', amount: '12' };
+  it('accepts a valid report (with optional https imageUrl)', () => {
+    ok(createReportSchema, valid);
+    ok(createReportSchema, { ...valid, imageUrl: 'https://cdn.example.com/a.jpg' });
+  });
+  it('rejects empty / oversized location', () => {
+    bad(createReportSchema, { ...valid, location: '' });
+    bad(createReportSchema, { ...valid, location: 'x'.repeat(501) });
+  });
+  it('rejects an invalid waste type', () => bad(createReportSchema, { ...valid, wasteType: 'banana' }));
+  it('rejects non-numeric / non-positive amount', () => {
+    bad(createReportSchema, { ...valid, amount: 'abc' });
+    bad(createReportSchema, { ...valid, amount: '0' });
+    bad(createReportSchema, { ...valid, amount: '-5' });
+  });
+  it('rejects a non-https / malformed imageUrl', () => {
+    bad(createReportSchema, { ...valid, imageUrl: 'http://x.com/a.jpg' });
+    bad(createReportSchema, { ...valid, imageUrl: 'not a url' });
+  });
+});
+
+describe('report status / task schemas', () => {
+  it('accept valid', () => {
+    ok(updateReportStatusSchema, { reportId: 5, status: 'approved' });
+    ok(updateTaskStatusSchema, { reportId: 5, newStatus: 'collected' });
+  });
+  it('reject bad id or status', () => {
+    bad(updateReportStatusSchema, { reportId: 0, status: 'approved' });
+    bad(updateReportStatusSchema, { reportId: -1, status: 'approved' });
+    bad(updateReportStatusSchema, { reportId: 1.5, status: 'approved' });
+    bad(updateReportStatusSchema, { reportId: 5, status: 'bogus' });
+    bad(updateTaskStatusSchema, { reportId: 5, newStatus: 'bogus' });
+  });
+});
+
+describe('pagination limit schemas', () => {
+  it('accept 1..100', () => {
+    ok(recentReportsSchema, { limit: 10 });
+    ok(wasteCollectionTasksSchema, { limit: 100 });
+  });
+  it('reject <=0, >100, float', () => {
+    bad(recentReportsSchema, { limit: 0 });
+    bad(recentReportsSchema, { limit: -1 });
+    bad(recentReportsSchema, { limit: 101 });
+    bad(recentReportsSchema, { limit: 2.5 });
+  });
+});
+
+describe('redeemRewardSchema', () => {
+  it('accepts 0 (redeem-all) and positive ids', () => {
+    ok(redeemRewardSchema, { rewardId: 0 });
+    ok(redeemRewardSchema, { rewardId: 7 });
+  });
+  it('rejects negative / float', () => {
+    bad(redeemRewardSchema, { rewardId: -1 });
+    bad(redeemRewardSchema, { rewardId: 1.5 });
+  });
+});
+
+describe('saveRewardSchema', () => {
+  it('accepts a valid grant', () => ok(saveRewardSchema, { recipientUserId: 3, amount: 50 }));
+  it('rejects bad recipient', () => bad(saveRewardSchema, { recipientUserId: 0, amount: 50 }));
+  it('rejects non-positive amount', () => {
+    bad(saveRewardSchema, { recipientUserId: 3, amount: 0 });
+    bad(saveRewardSchema, { recipientUserId: 3, amount: -10 });
+  });
+  it(`rejects amount over the cap (${MAX_POINTS})`, () =>
+    bad(saveRewardSchema, { recipientUserId: 3, amount: MAX_POINTS + 1 }));
+});
+
+describe('id-only schemas', () => {
+  it('collectedWaste / markNotificationRead accept positive, reject non-positive', () => {
+    ok(collectedWasteSchema, { reportId: 1 });
+    bad(collectedWasteSchema, { reportId: 0 });
+    ok(markNotificationReadSchema, { notificationId: 9 });
+    bad(markNotificationReadSchema, { notificationId: -3 });
+  });
+});
+
+describe('sessionRequestSchema', () => {
+  it('accepts a non-empty token', () => ok(sessionRequestSchema, { idToken: 'header.payload.sig' }));
+  it('rejects empty / oversized / missing', () => {
+    bad(sessionRequestSchema, { idToken: '' });
+    bad(sessionRequestSchema, { idToken: 'x'.repeat(4097) });
+    bad(sessionRequestSchema, {});
+  });
+});
+
+describe('validate() helper', () => {
+  it('returns parsed data on success', () => {
+    expect(validate(collectedWasteSchema, { reportId: 4 })).toEqual({ reportId: 4 });
+  });
+  it('throws ValidationError (not a raw ZodError) on failure', () => {
+    try {
+      validate(collectedWasteSchema, { reportId: 0 });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      expect(e).not.toBeInstanceOf(ZodError);
+      expect((e as ValidationError).issues.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
 ## KWM-017 — Zod validation on every server action

  Adds input validation at every server-action boundary and the session route.
  Inputs are validated *after* the auth guard and rejected with a typed
  `ValidationError` before any DB write.

  ### What changed
  - **`lib/validation.ts`** — `ValidationError` (third member of the action error
    taxonomy, alongside Unauthorized/Forbidden) + `validate()` helper that throws
    it (never a raw `ZodError`).
  - **`utils/db/schemas/`** — one schema per input-bearing action; enum schemas are
    derived from the drizzle `pgEnum.enumValues` (single source of truth, no drift).
    Shared primitives in `common.ts`.
  - **`utils/db/actions.ts`** — 10 actions now `validate(...)` their inputs after
    the RBAC guard.
  - **`app/api/auth/session/route.ts`** — body validated with `sessionRequestSchema`;
    returns 400 on `ValidationError`.
  - **`createReport`**: dropped the client-supplied `verificationResult` and the
    until KWM-043 introduces trusted verification.

  ### Security
  - `saveReward.amount` is now hard-capped at **`MAX_POINTS = 10_000`** (temporary;
    no business rule exists yet — revisit in KWM-011). Reduces the reward
    free-mint surface (risk R-3).
  - `createReport` no longer trusts a client verification verdict.

  ### Actions validated (10) + 1 route
  createReport, markNotificationAsRead, redeemReward, createCollectedWaste,
  saveCollectedWaste, updateTaskStatus, saveReward, updateReportStatus,
  getRecentReports, getWasteCollectionTasks, and POST /api/auth/session.
  (8 input-less read actions need no schema — identity is session-derived.)

  ### Tests
  `utils/db/schemas/schemas.test.ts` — reject + accept cases for every schema and
  the `validate()` helper (throws `ValidationError`, not `ZodError`). **33/33** pass.

  ### Validation
  `npm test` 33/33 · `npm run lint` clean · `npm run typecheck` exit 0 ·
  `npm run build` 8/8 pages.

  ### Scope
  No DB migration, no RBAC change, no reward-system redesign. `zod ^4.4.3` added.

  ### Prepares
  KWM-019 (maps `ValidationError` → `Result.code`), KWM-011/012 (reuses capped
  points/reward-id schemas), KWM-018 (validate-then-transact ordering).

closes #24 